### PR TITLE
fix multi-line DEBUG_TRACE macro calls

### DIFF
--- a/templates/GLR_Lib.hs
+++ b/templates/GLR_Lib.hs
@@ -178,8 +178,7 @@ doActions stks (tok:toks)
                              shiftAll tok_form stks'
                          | tok_form <- tok ]
 	let new_stks = merge $ concat stkss
-	DEBUG_TRACE(unlines $ ("Stacks after R*/S pass" ++ show tok)
-				: map show new_stks)
+	DEBUG_TRACE(unlines $ ("Stacks after R*/S pass" ++ show tok) : map show new_stks)
 	case new_stks of            -- did this token kill stacks?
 	  [] -> case toks of
 		  []  -> return $ Right []	   -- ok if no more tokens
@@ -207,8 +206,7 @@ reduceAll cyclic_names itok@(i,tok) (stk:stks)
 	           ]
 	           -- WARNING: incomplete if more than one Empty in a prod(!)
 	           -- WARNING: can avoid by splitting emps/non-emps
-	DEBUG_TRACE(unlines $ ("Packing reds = " ++ show (length reds))
-			    : map show reds)
+	DEBUG_TRACE(unlines $ ("Packing reds = " ++ show (length reds)) : map show reds)
 	stks' <- foldM (pack i) stks reds
 	let new_cyclic = [ m | (m,0,_) <- rs
 	                     , UEQ(this_state, goto this_state m)


### PR DESCRIPTION
Using GHC 7.8.3 (e.g. under the Haskell Platform 2014.2.0.0) the template file `GLR_Lib` is created with two indentation errors:
- line 161, the line `case new_stks of` begins with a space and not a tab
- line 190, the line `stks' <- foldM (pack i) stks reds` begins with a space and not a tab

(These line numbers reference the files generated by `happy-1.19.4`)

These indentation errors will cause compile errors when happy is used with the `--glr` flag. For instance, see this StackOverflow question: http://stackoverflow.com/q/27150105/866915

The problem seems to be due to the multi-line macro call just before these lines. Changing them to a single line fixes the problem. For some reason `ghc -E -cpp` is replacing the leading tab on these lines with a space.
