### PR TITLE
RFC: On parse error - show the next possible tokens

### DIFF
--- a/doc/happy.xml
+++ b/doc/happy.xml
@@ -3482,7 +3482,29 @@ any projection function.</para>
 	<para>Specifies the function to be called in the event of a
 	parse error.  The type of <literal>&lt;identifier&gt;</literal> varies
 	depending on the presence of <literal>%lexer</literal> (see
-	<xref linkend="sec-monad-summary" />).</para>
+	<xref linkend="sec-monad-summary" />) and <literal>%errorhandlertype</literal>
+	(see the following).</para>
+      </sect2>
+
+      <sect2 id="sec-errorhandlertype-directive">
+	<title>Additional error information</title>
+
+<programlisting>
+%errorhandlertype (explist | default)
+</programlisting>
+
+	<indexterm>
+	  <primary><literal>%errorhandlertype</literal></primary>
+	</indexterm>
+
+	<para>(optional) The expected type of the user-supplied error handling can be
+	applied with additional information. By default, no information is added, for
+	compatibility with previous versions. However, if <literal>explist</literal>
+	is provided with this directive, then the first application will be of
+	type <literal>[String]</literal>, providing a description of possible tokens
+	that would not have failed the parser in place of the token that has caused
+	the error.
+	</para>
       </sect2>
 
       <sect2 id="sec-attributes">

--- a/src/AbsSyn.lhs
+++ b/src/AbsSyn.lhs
@@ -10,7 +10,7 @@ Here is the abstract syntax of the language we parse.
 >       AbsSyn(..), Directive(..),
 >       getTokenType, getTokenSpec, getParserNames, getLexer,
 >       getImportedIdentity, getMonad, getError,
->       getPrios, getPrioNames, getExpect,
+>       getPrios, getPrioNames, getExpect, getErrorSig,
 >       getAttributes, getAttributetype,
 >       Rule,Prod,Term(..)
 >  ) where
@@ -45,6 +45,7 @@ generate some error messages.
 >       | TokenSpec     [(a,String)]            -- %token
 >       | TokenName     String (Maybe String) Bool -- %name/%partial (True <=> %partial)
 >       | TokenLexer    String String           -- %lexer
+>       | TokenErrorSig String                  -- %errorsig
 >       | TokenImportedIdentity                                 -- %importedidentity
 >       | TokenMonad    String String String String -- %monad
 >       | TokenNonassoc [String]                -- %nonassoc
@@ -124,6 +125,13 @@ generate some error messages.
 >               [t] -> Just t
 >               []  -> Nothing
 >               _   -> error "multiple error directives"
+
+> getErrorSig :: [Directive t] -> String
+> getErrorSig ds
+>       = case [ a | (TokenErrorSig a) <- ds ] of
+>               [t] -> t
+>               []  -> "default"
+>               _   -> error "multiple errorsig directives"
 
 > getAttributes :: [Directive t] -> [(String, String)]
 > getAttributes ds

--- a/src/AbsSyn.lhs
+++ b/src/AbsSyn.lhs
@@ -7,10 +7,10 @@ Abstract syntax for grammar files.
 Here is the abstract syntax of the language we parse.
 
 > module AbsSyn (
->       AbsSyn(..), Directive(..),
+>       AbsSyn(..), Directive(..), ErrorHandlerType(..),
 >       getTokenType, getTokenSpec, getParserNames, getLexer,
 >       getImportedIdentity, getMonad, getError,
->       getPrios, getPrioNames, getExpect, getErrorSig,
+>       getPrios, getPrioNames, getExpect, getErrorHandlerType,
 >       getAttributes, getAttributetype,
 >       Rule,Prod,Term(..)
 >  ) where
@@ -40,12 +40,16 @@ Parser Generator Directives.
 ToDo: find a consistent way to analyse all the directives together and
 generate some error messages.
 
+> data ErrorHandlerType
+>   = ErrorHandlerTypeDefault
+>   | ErrorHandlerTypeExpList
+>
 > data Directive a
 >       = TokenType     String                  -- %tokentype
 >       | TokenSpec     [(a,String)]            -- %token
 >       | TokenName     String (Maybe String) Bool -- %name/%partial (True <=> %partial)
 >       | TokenLexer    String String           -- %lexer
->       | TokenErrorSig String                  -- %errorsig
+>       | TokenErrorHandlerType String          -- %errorhandlertype
 >       | TokenImportedIdentity                                 -- %importedidentity
 >       | TokenMonad    String String String String -- %monad
 >       | TokenNonassoc [String]                -- %nonassoc
@@ -126,12 +130,15 @@ generate some error messages.
 >               []  -> Nothing
 >               _   -> error "multiple error directives"
 
-> getErrorSig :: [Directive t] -> String
-> getErrorSig ds
->       = case [ a | (TokenErrorSig a) <- ds ] of
->               [t] -> t
->               []  -> "default"
->               _   -> error "multiple errorsig directives"
+> getErrorHandlerType :: [Directive t] -> ErrorHandlerType
+> getErrorHandlerType ds
+>       = case [ a | (TokenErrorHandlerType a) <- ds ] of
+>               [t] -> case t of
+>                        "explist" -> ErrorHandlerTypeExpList
+>                        "default" -> ErrorHandlerTypeDefault
+>                        _ -> error "unsupported %errorhandlertype value"
+>               []  -> ErrorHandlerTypeDefault
+>               _   -> error "multiple errorhandlertype directives"
 
 > getAttributes :: [Directive t] -> [(String, String)]
 > getAttributes ds

--- a/src/Grammar.lhs
+++ b/src/Grammar.lhs
@@ -64,7 +64,8 @@ Here is our mid-section datatype
 >               attributes        :: [(String,String)],
 >               attributetype     :: String,
 >               lexer             :: Maybe (String,String),
->               error_handler     :: Maybe String
+>               error_handler     :: Maybe String,
+>               error_sig         :: String
 >       }
 
 #ifdef DEBUG
@@ -371,6 +372,7 @@ Get the token specs in terms of Names.
 >               monad             = getMonad dirs,
 >               lexer             = getLexer dirs,
 >               error_handler     = getError dirs,
+>               error_sig         = getErrorSig dirs,
 >               token_type        = getTokenType dirs,
 >               expect            = getExpect dirs,
 >               attributes        = attrs,

--- a/src/Grammar.lhs
+++ b/src/Grammar.lhs
@@ -9,7 +9,7 @@ Here is our mid-section datatype
 > module Grammar (
 >       Name,
 >
->       Production, Grammar(..), mangler,
+>       Production, Grammar(..), mangler, ErrorHandlerType(..),
 >
 >       LRAction(..), ActionTable, Goto(..), GotoTable, Priority(..),
 >       Assoc(..),
@@ -65,7 +65,7 @@ Here is our mid-section datatype
 >               attributetype     :: String,
 >               lexer             :: Maybe (String,String),
 >               error_handler     :: Maybe String,
->               error_sig         :: String
+>               error_sig         :: ErrorHandlerType
 >       }
 
 #ifdef DEBUG
@@ -372,7 +372,7 @@ Get the token specs in terms of Names.
 >               monad             = getMonad dirs,
 >               lexer             = getLexer dirs,
 >               error_handler     = getError dirs,
->               error_sig         = getErrorSig dirs,
+>               error_sig         = getErrorHandlerType dirs,
 >               token_type        = getTokenType dirs,
 >               expect            = getExpect dirs,
 >               attributes        = attrs,

--- a/src/Lexer.lhs
+++ b/src/Lexer.lhs
@@ -37,6 +37,7 @@ The lexer.
 >       | TokSpecId_Token       -- %token
 >       | TokSpecId_Name        -- %name
 >       | TokSpecId_Partial     -- %partial
+>       | TokSpecId_ErrorSig  -- %errorsig
 >       | TokSpecId_Lexer       -- %lexer
 >       | TokSpecId_ImportedIdentity -- %importedidentity
 >       | TokSpecId_Monad       -- %monad
@@ -133,6 +134,8 @@ followed by a special identifier.
 >               returnToken cont (TokenKW TokSpecId_Prec) rest
 >       'e':'x':'p':'e':'c':'t':rest ->
 >               returnToken cont (TokenKW TokSpecId_Expect) rest
+>       'e':'r':'r':'o':'r':'s':'i':'g':rest ->
+>               returnToken cont (TokenKW TokSpecId_ErrorSig) rest
 >       'e':'r':'r':'o':'r':rest ->
 >               returnToken cont (TokenKW TokSpecId_Error) rest
 >       'a':'t':'t':'r':'i':'b':'u':'t':'e':'t':'y':'p':'e':rest ->

--- a/src/Lexer.lhs
+++ b/src/Lexer.lhs
@@ -37,7 +37,7 @@ The lexer.
 >       | TokSpecId_Token       -- %token
 >       | TokSpecId_Name        -- %name
 >       | TokSpecId_Partial     -- %partial
->       | TokSpecId_ErrorSig  -- %errorsig
+>       | TokSpecId_ErrorHandlerType    -- %errorhandlertype
 >       | TokSpecId_Lexer       -- %lexer
 >       | TokSpecId_ImportedIdentity -- %importedidentity
 >       | TokSpecId_Monad       -- %monad
@@ -134,8 +134,8 @@ followed by a special identifier.
 >               returnToken cont (TokenKW TokSpecId_Prec) rest
 >       'e':'x':'p':'e':'c':'t':rest ->
 >               returnToken cont (TokenKW TokSpecId_Expect) rest
->       'e':'r':'r':'o':'r':'s':'i':'g':rest ->
->               returnToken cont (TokenKW TokSpecId_ErrorSig) rest
+>       'e':'r':'r':'o':'r':'h':'a':'n':'d':'l':'e':'r':'t':'y':'p':'e':rest ->
+>               returnToken cont (TokenKW TokSpecId_ErrorHandlerType) rest
 >       'e':'r':'r':'o':'r':rest ->
 >               returnToken cont (TokenKW TokSpecId_Error) rest
 >       'a':'t':'t':'r':'i':'b':'u':'t':'e':'t':'y':'p':'e':rest ->

--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -195,7 +195,7 @@ Add any special options or imports required by the parsing machinery.
 >       let
 >           header = Just (
 >                       (case hd of Just s -> s; Nothing -> "")
->                       ++ importsToInject target cli
+>                       ++ importsToInject cli
 >                    )
 >       in
 
@@ -208,7 +208,7 @@ Branch off to GLR parser production
 >           filtering  | OptGLR_Filter `elem` cli = UseFiltering
 >                      | otherwise                = NoFiltering
 >           ghc_exts   | OptGhcTarget `elem` cli  = UseGhcExts
->                                                   (importsToInject target cli)
+>                                                   (importsToInject cli)
 >                                                   (optsToInject target cli)
 >                      | otherwise                = NoGhcExts
 >           debug      = OptDebugParser `elem` cli
@@ -483,14 +483,12 @@ GHC version-dependent stuff in it.
 >       | OptDebugParser `elem` cli = "-cpp"
 >       | otherwise                 = ""
 
-> importsToInject :: Target -> [CLIFlags] -> String
-> importsToInject tgt cli =
->     concat ["\n", array_import, glaexts_import, debug_imports, applicative_imports]
+> importsToInject :: [CLIFlags] -> String
+> importsToInject cli =
+>     concat ["\n", import_array, import_bits,
+>             glaexts_import, debug_imports, applicative_imports]
 >   where
 >       glaexts_import | is_ghc         = import_glaexts
->                      | otherwise      = ""
->
->       array_import   | is_array       = import_array
 >                      | otherwise      = ""
 >
 >       debug_imports  | is_debug       = import_debug
@@ -500,7 +498,6 @@ GHC version-dependent stuff in it.
 >
 >       is_ghc   = OptGhcTarget `elem` cli
 >       is_debug = OptDebugParser `elem` cli
->       is_array = tgt == TargetArrayBased
 
 CPP is turned on for -fglasgow-exts, so we can use conditional compilation:
 
@@ -509,6 +506,9 @@ CPP is turned on for -fglasgow-exts, so we can use conditional compilation:
 
 > import_array :: String
 > import_array = "import qualified Data.Array as Happy_Data_Array\n"
+
+> import_bits :: String
+> import_bits = "import qualified Data.Bits as Bits\n"
 
 > import_debug :: String
 > import_debug =

--- a/src/Parser.ly
+++ b/src/Parser.ly
@@ -31,7 +31,7 @@ The parser.
 >       spec_prec       { TokenKW      TokSpecId_Prec }
 >       spec_expect     { TokenKW      TokSpecId_Expect }
 >       spec_error      { TokenKW      TokSpecId_Error }
->       spec_errorsig   { TokenKW      TokSpecId_ErrorSig }
+>       spec_errorhandlertype   { TokenKW      TokSpecId_ErrorHandlerType }
 >       spec_attribute  { TokenKW      TokSpecId_Attribute }
 >       spec_attributetype      { TokenKW      TokSpecId_Attributetype }
 >       code            { TokenInfo $$ TokCodeQuote }
@@ -119,7 +119,7 @@ The parser.
 >       | spec_left ids                 { TokenLeft $2 }
 >       | spec_expect int               { TokenExpect $2 }
 >       | spec_error code               { TokenError $2 }
->       | spec_errorsig id              { TokenErrorSig $2 }
+>       | spec_errorhandlertype id              { TokenErrorHandlerType $2 }
 >       | spec_attributetype code       { TokenAttributetype $2 }
 >       | spec_attribute id code        { TokenAttribute $2 $3 }
 

--- a/src/Parser.ly
+++ b/src/Parser.ly
@@ -31,6 +31,7 @@ The parser.
 >       spec_prec       { TokenKW      TokSpecId_Prec }
 >       spec_expect     { TokenKW      TokSpecId_Expect }
 >       spec_error      { TokenKW      TokSpecId_Error }
+>       spec_errorsig   { TokenKW      TokSpecId_ErrorSig }
 >       spec_attribute  { TokenKW      TokSpecId_Attribute }
 >       spec_attributetype      { TokenKW      TokSpecId_Attributetype }
 >       code            { TokenInfo $$ TokCodeQuote }
@@ -118,6 +119,7 @@ The parser.
 >       | spec_left ids                 { TokenLeft $2 }
 >       | spec_expect int               { TokenExpect $2 }
 >       | spec_error code               { TokenError $2 }
+>       | spec_errorsig id              { TokenErrorSig $2 }
 >       | spec_attributetype code       { TokenAttributetype $2 }
 >       | spec_attribute id code        { TokenAttribute $2 $3 }
 

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -553,19 +553,18 @@ machinery to discard states in the parser...
 >             produceActions (_, LR'Fail{-'-}) = id
 >             produceActions (t, action'@(LR'Reduce{-'-} _ _))
 >                | action' == default_act = id
->                | otherwise = actionFunction t
->                            . productAction action'
+>                | otherwise = producePossiblyFailingAction t action'
 >             produceActions (t, action')
->               = actionFunction t
->               . productAction action'
+>               = producePossiblyFailingAction t action'
 >
->             productAction action'
->               = mkAction action'
->                 . (case action' of
->                     LR'Fail -> str " []"
->                     LR'MustFail -> str " []"
->                     _ -> str "")
->                 . str "\n"
+>             producePossiblyFailingAction t action'
+>               = actionFunction t
+>               . mkAction action'
+>               . (case action' of
+>                   LR'Fail -> str " []"
+>                   LR'MustFail -> str " []"
+>                   _ -> str "")
+>               . str "\n"
 >
 >             produceGotos (t, Goto i)
 >               = actionFunction t
@@ -783,15 +782,14 @@ MonadStuff:
 
 An error handler specified with %error is passed the current token
 when used with %lexer, but happyError (the old way but kept for
-compatibility) is not passed the current token. Also, the %errorsig
+compatibility) is not passed the current token. Also, the %errorhandlertype
 directive determins the API of the provided function.
 
 >    errorHandler =
 >       case error_handler' of
 >               Just h  -> case error_sig' of
->                              "explist" -> str h
->                              "default" -> str "(\\(tokens, _) -> " . str h . str " tokens)"
->                              _ -> error "unsupported %errorsig value"
+>                              ErrorHandlerTypeExpList -> str h
+>                              ErrorHandlerTypeDefault -> str "(\\(tokens, _) -> " . str h . str " tokens)"
 >               Nothing -> case lexer' of
 >                               Nothing -> str "(\\(tokens, _) -> happyError tokens)"
 >                               Just _  -> str "(\\(tokens, explist) -> happyError)"

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -44,8 +44,9 @@ HAPPY_ENDIF
 #define IF_GHC(x)
 #endif
 
-#if defined(HAPPY_ARRAY)
 data Happy_IntList = HappyCons FAST_INT Happy_IntList
+
+#if defined(HAPPY_ARRAY)
 #define CONS(h,t) (HappyCons (h) (t))
 #else
 #define CONS(h,t) ((h):(t))
@@ -114,7 +115,7 @@ happyDoAction i tk st
                       ",\taction: ")
           case action of
                 ILIT(0)           -> DEBUG_TRACE("fail.\n")
-                                     happyFail (happy_explist_per_state (IBOX(st) :: Int)) i tk st
+                                     happyFail (happyExpListPerState (IBOX(st) :: Int)) i tk st
                 ILIT(-1)          -> DEBUG_TRACE("accept.\n")
                                      happyAccept i tk st
                 n | LT(n,(ILIT(0) :: FAST_INT)) -> DEBUG_TRACE("reduce (rule " ++ show rule
@@ -135,6 +136,8 @@ happyDoAction i tk st
           | check     = indexShortOffAddr happyTable off_i
           | otherwise = indexShortOffAddr happyDefActions st
 
+#endif /* HAPPY_ARRAY */
+
 #ifdef HAPPY_GHC
 indexShortOffAddr (HappyA# arr) off =
         Happy_GHC_Exts.narrow16Int# i
@@ -147,11 +150,18 @@ indexShortOffAddr (HappyA# arr) off =
 indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif
 
+
+readArrayBit arr bit =
+    Bits.testBit IBOX(indexShortOffAddr arr (unbox_int $ bit `div` 16)) (bit `mod` 16)
+#ifdef HAPPY_GHC
+  where unbox_int (Happy_GHC_Exts.I# x) = x
+#else
+  where unbox_int = id
+#endif
+
 #ifdef HAPPY_GHC
 data HappyAddr = HappyA# Happy_GHC_Exts.Addr#
 #endif
-
-#endif /* HAPPY_ARRAY */
 
 -----------------------------------------------------------------------------
 -- HappyState data type (not arrays)

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -114,7 +114,7 @@ happyDoAction i tk st
                       ",\taction: ")
           case action of
                 ILIT(0)           -> DEBUG_TRACE("fail.\n")
-                                     happyFail i tk st
+                                     happyFail (happy_explist_per_state (IBOX(st) :: Int)) i tk st
                 ILIT(-1)          -> DEBUG_TRACE("accept.\n")
                                      happyAccept i tk st
                 n | LT(n,(ILIT(0) :: FAST_INT)) -> DEBUG_TRACE("reduce (rule " ++ show rule
@@ -182,30 +182,30 @@ happyShift new_state i tk st sts stk =
 -- happyReduce is specialised for the common cases.
 
 happySpecReduce_0 i fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happySpecReduce_0 nt fn j tk st@(HAPPYSTATE(action)) sts stk
      = GOTO(action) nt j tk st CONS(st,sts) (fn `HappyStk` stk)
 
 happySpecReduce_1 i fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happySpecReduce_1 nt fn j tk _ sts@(CONS(st@HAPPYSTATE(action),_)) (v1`HappyStk`stk')
      = let r = fn v1 in
        happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
 
 happySpecReduce_2 i fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happySpecReduce_2 nt fn j tk _ CONS(_,sts@(CONS(st@HAPPYSTATE(action),_))) (v1`HappyStk`v2`HappyStk`stk')
      = let r = fn v1 v2 in
        happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
 
 happySpecReduce_3 i fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happySpecReduce_3 nt fn j tk _ CONS(_,CONS(_,sts@(CONS(st@HAPPYSTATE(action),_)))) (v1`HappyStk`v2`HappyStk`v3`HappyStk`stk')
      = let r = fn v1 v2 v3 in
        happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
 
 happyReduce k i fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happyReduce k nt fn j tk st sts stk
      = case happyDrop MINUS(k,(ILIT(1) :: FAST_INT)) sts of
          sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
@@ -213,7 +213,7 @@ happyReduce k nt fn j tk st sts stk
                 happyDoSeq r (GOTO(action) nt j tk st1 sts1 r)
 
 happyMonadReduce k nt fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happyMonadReduce k nt fn j tk st sts stk =
       case happyDrop k CONS(st,sts) of
         sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
@@ -221,7 +221,7 @@ happyMonadReduce k nt fn j tk st sts stk =
           happyThen1 (fn stk tk) (\r -> GOTO(action) nt j tk st1 sts1 (r `HappyStk` drop_stk))
 
 happyMonad2Reduce k nt fn ERROR_TOK tk st sts stk
-     = happyFail ERROR_TOK tk st sts stk
+     = happyFail [] ERROR_TOK tk st sts stk
 happyMonad2Reduce k nt fn j tk st sts stk =
       case happyDrop k CONS(st,sts) of
         sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
@@ -260,10 +260,10 @@ happyGoto action j tk st = action j j tk (HappyState action)
 -- Error recovery (ERROR_TOK is the error token)
 
 -- parse error if we are in recovery and we fail again
-happyFail ERROR_TOK tk old_st _ stk@(x `HappyStk` _) =
+happyFail explist ERROR_TOK tk old_st _ stk@(x `HappyStk` _) =
      let i = GET_ERROR_TOKEN(x) in
 --      trace "failing" $ 
-        happyError_ i tk
+        happyError_ explist i tk
 
 {-  We don't need state discarding for our restricted implementation of
     "error".  In fact, it can cause some bogus parses, so I've disabled it
@@ -278,7 +278,7 @@ happyFail  ERROR_TOK tk old_st CONS(HAPPYSTATE(action),sts)
 
 -- Enter error recovery: generate an error token,
 --                       save the old token and carry on.
-happyFail  i tk HAPPYSTATE(action) sts stk =
+happyFail explist i tk HAPPYSTATE(action) sts stk =
 --      trace "entering error recovery" $
         DO_ACTION(action,ERROR_TOK,tk,sts, MK_ERROR_TOKEN(i) `HappyStk` stk)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
 	bogus-token.y bug002.y Partial.ly \
 	AttrGrammar001.y AttrGrammar002.y \
-	test_rules.y monaderror.y
+	test_rules.y monaderror.y monaderror-explist.y
 
 ERROR_TESTS = error001.y
 

--- a/tests/monaderror-explist.y
+++ b/tests/monaderror-explist.y
@@ -1,0 +1,70 @@
+{
+module Main where
+
+import Data.Char
+import Control.Monad.Error
+import System.Exit
+import System.Environment (getProgName)
+import Data.List (isPrefixOf)
+}
+
+%name parseFoo
+%tokentype { Token }
+%errorsig explist
+%error { handleErrorExpList }
+
+%monad { ParseM } { (>>=) } { return }
+
+%token
+        'S'             { TokenSucc }
+        'Z'             { TokenZero }
+        'T'             { TokenTest }
+
+%%
+
+Exp         :       'Z'           { 0 }
+            |       'T' 'Z' Exp   { $3 + 1 }
+            |       'S' Exp       { $2 + 1 }
+
+{
+
+type ParseM a = Either ParseError a
+data ParseError
+        = ParseError (Maybe (Token, [String]))
+        | StringError String
+    deriving (Eq,Show)
+instance Error ParseError where
+    strMsg = StringError
+
+data Token
+        = TokenSucc
+        | TokenZero
+	| TokenTest
+    deriving (Eq,Show)
+
+handleErrorExpList :: ([Token], [String]) -> ParseM a
+handleErrorExpList ([], _) = throwError $ ParseError Nothing
+handleErrorExpList (ts, explist) = throwError $ ParseError $ Just $ (head ts, explist)
+
+lexer :: String -> [Token]
+lexer [] = []
+lexer (c:cs)
+    | isSpace c = lexer cs
+    | c == 'S'  = TokenSucc:(lexer cs)
+    | c == 'Z'  = TokenZero:(lexer cs)
+    | c == 'T'  = TokenTest:(lexer cs)
+    | otherwise = error "lexer error"
+
+main :: IO ()
+main = do
+  test "Z Z" $ Left (ParseError (Just (TokenZero,[])))
+  test "T S" $ Left (ParseError (Just (TokenSucc,["'Z'"])))
+
+  where
+    test inp exp = do
+      putStrLn $ "testing " ++ inp
+      let tokens = lexer inp
+      when (parseFoo tokens /= exp) $ do
+        print (parseFoo tokens)
+        exitWith (ExitFailure 1)
+}

--- a/tests/monaderror-explist.y
+++ b/tests/monaderror-explist.y
@@ -10,7 +10,7 @@ import Data.List (isPrefixOf)
 
 %name parseFoo
 %tokentype { Token }
-%errorsig explist
+%errorhandlertype explist
 %error { handleErrorExpList }
 
 %monad { ParseM } { (>>=) } { return }


### PR DESCRIPTION
People asked for a patch upstream - so here's the place to start a discussion.

In this change, I've made sure that 'cabal test' still passes, and the interface to unmodified users is preserved. But you would probably have more comments.