### PR TITLE
Add signature generation for using typeclasses in parsers

### DIFF
--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -912,7 +912,8 @@ directive determins the API of the provided function.
 >       . maybe_tks
 >       . str " = "
 >       . str unmonad
->       . str "happyThen (happyParse "
+>       . str "happySomeParser where\n"
+>       . str " happySomeParser = happyThen (happyParse "
 >       . case target of
 >            TargetHaskell -> str "action_" . shows no
 >            TargetArrayBased

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -428,20 +428,22 @@ The token conversion function.
 >       Just (lexer'',eof') ->
 >       case (target, ghc) of
 >          (TargetHaskell, True) ->
->                 str "happyNewToken :: (Happy_GHC_Exts.Int#\n"
+>             let pcont = str monad_context
+>                 pty = str monad_tycon  in
+>                 str "happyNewToken :: " . pcont . str " => "
+>               . str "(Happy_GHC_Exts.Int#\n"
 >               . str "                   -> Happy_GHC_Exts.Int#\n"
 >               . str "                   -> Token\n"
->               . str "                   -> HappyState Token (t -> [Char] -> Int -> ParseResult a)\n"
->               . str "                   -> [HappyState Token (t -> [Char] -> Int -> ParseResult a)]\n"
+>               . str "                   -> HappyState Token (t -> "
+>               . pty . str " a)\n"
+>               . str "                   -> [HappyState Token (t -> "
+>               . pty . str " a)]\n"
 >               . str "                   -> t\n"
->               . str "                   -> [Char]\n"
->               . str "                   -> Int\n"
->               . str "                   -> ParseResult a)\n"
->               . str "                 -> [HappyState Token (t -> [Char] -> Int -> ParseResult a)]\n"
+>               . str "                   -> " . pty . str " a)\n"
+>               . str "                 -> [HappyState Token (t -> "
+>               . pty . str " a)]\n"
 >               . str "                 -> t\n"
->               . str "                 -> [Char]\n"
->               . str "                 -> Int\n"
->               . str "                 -> ParseResult a\n"
+>               . str "                 -> " . pty . str " a\n"
 >          _ -> id
 >       . str "happyNewToken action sts stk\n\t= "
 >       . str lexer''

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,8 @@ TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
 	bogus-token.y bug002.y Partial.ly \
 	AttrGrammar001.y AttrGrammar002.y \
-	test_rules.y monaderror.y monaderror-explist.y
+	test_rules.y monaderror.y monaderror-explist.y \
+	typeclass_monad001.y typeclass_monad002.ly typeclass_monad_lexer.y
 
 ERROR_TESTS = error001.y
 

--- a/tests/typeclass_monad001.y
+++ b/tests/typeclass_monad001.y
@@ -1,0 +1,93 @@
+-- Testing %monad without %lexer, using the IO monad.
+
+{
+module Main where
+
+import Control.Monad.Trans
+import System.IO
+import Data.Char
+}
+
+%name calc
+%tokentype { Token }
+
+%token 	num		{ TokenNum $$ }
+	'+'		{ TokenPlus }
+	'-'		{ TokenMinus }
+	'*'		{ TokenTimes }
+	'/'		{ TokenDiv }
+	'^'		{ TokenExp }
+	'\n'		{ TokenEOL }
+	'('		{ TokenOB }
+	')'		{ TokenCB }
+
+%left '-' '+'
+%left '*'
+%nonassoc '/'
+%left NEG     -- negation--unary minus
+%right '^'    -- exponentiation
+
+%monad { (MonadIO m) } { m } { (>>=) } { return }
+
+%%
+input	: {- empty string -}   { () }
+        | input line	      { $1 }
+
+line	: '\n'		     { () }
+        | exp '\n'  	     {% hPutStr stdout (show $1) }
+
+exp	: num                { $1         }
+        | exp '+' exp        { $1 + $3    }
+        | exp '-' exp        { $1 - $3    }
+        | exp '*' exp        { $1 * $3    }
+        | exp '/' exp        { $1 / $3    }
+        | '-' exp  %prec NEG { -$2        }
+--        | exp '^' exp        { $1 ^ $3    }
+        | '(' exp ')'        { $2         }
+
+{
+main = do
+   calc (lexer "1 + 2 * 3 / 4\n")
+
+{-
+   -- check that non-associative operators can't be used together
+   r <- try (calc (lexer "1 / 2 / 3"))
+   case r of
+       Left e  -> return ()
+       Right _ -> ioError (userError "fail!")
+-}
+
+data Token
+	= TokenExp
+	| TokenEOL
+	| TokenNum Double
+	| TokenPlus
+	| TokenMinus
+	| TokenTimes
+	| TokenDiv
+	| TokenOB
+	| TokenCB
+
+-- and a simple lexer that returns this datastructure.
+
+lexer :: String -> [Token]
+lexer [] = []
+lexer ('\n':cs) = TokenEOL : lexer cs
+lexer (c:cs)
+	| isSpace c = lexer cs
+	| isDigit c = lexNum (c:cs)
+lexer ('+':cs) = TokenPlus : lexer cs
+lexer ('-':cs) = TokenMinus : lexer cs
+lexer ('*':cs) = TokenTimes : lexer cs
+lexer ('/':cs) = TokenDiv : lexer cs
+lexer ('^':cs) = TokenExp : lexer cs
+lexer ('(':cs) = TokenOB : lexer cs
+lexer (')':cs) = TokenCB : lexer cs
+
+lexNum cs = TokenNum (read num) : lexer rest
+	where (num,rest) = span isNum cs
+	      isNum c = isDigit c || c == '.'
+
+
+happyError tokens = liftIO (ioError (userError "parse error"))
+}

--- a/tests/typeclass_monad002.ly
+++ b/tests/typeclass_monad002.ly
@@ -1,0 +1,185 @@
+-----------------------------------------------------------------------------
+Test for monadic Happy Parsers, Simon Marlow 1996.
+
+> {
+> {-# OPTIONS_GHC -fglasgow-exts #-}
+> -- -fglasgow-exts required because P is a type synonym, and Happy uses it
+> -- unsaturated.
+> import Data.Char
+> }
+
+> %name calc
+> %tokentype { Token }
+
+> %monad { (Monad m) } { P m } { thenP } { returnP }
+> %lexer { lexer } { TokenEOF }
+
+> %token
+>	let		{ TokenLet }
+>	in		{ TokenIn }
+>	int		{ TokenInt $$ }
+>	var		{ TokenVar $$ }
+>	'='		{ TokenEq }
+>	'+'		{ TokenPlus }
+>	'-'		{ TokenMinus }
+>	'*'		{ TokenTimes }
+>	'/'		{ TokenDiv }
+>	'('		{ TokenOB }
+>	')'		{ TokenCB }
+
+> %%
+
+> Exp :: {Exp}
+>     : let var '=' Exp in Exp	{% \s l -> return (ParseOk (Let l $2 $4 $6)) }
+>     | Exp1			{ Exp1 $1 }
+>
+> Exp1 :: {Exp1}
+>      : Exp1 '+' Term		{ Plus $1 $3 }
+>      | Exp1 '-' Term		{ Minus $1 $3 }
+>      | Term			{ Term $1 }
+>
+> Term :: {Term}
+>      : Term '*' Factor	{ Times $1 $3 }
+>      | Term '/' Factor	{ Div $1 $3 }
+>      | Factor			{ Factor $1 }
+>
+
+> Factor :: {Factor}
+>        : int			{ Int $1 }
+> 	 | var			{ Var $1 }
+> 	 | '(' Exp ')'		{ Brack $2 }
+
+> {
+
+-----------------------------------------------------------------------------
+The monad serves three purposes:
+
+	* it passes the input string around
+	* it passes the current line number around
+	* it deals with success/failure.
+
+> data ParseResult a
+>	= ParseOk a
+>	| ParseFail String
+
+> type P m a = String -> Int -> m (ParseResult a)
+
+> thenP :: Monad m => P m a -> (a -> P m b) -> P m b
+> m `thenP` k = \s l ->
+>   do
+>     res <- m s l
+>     case res of
+>       ParseFail s -> return (ParseFail s)
+>       ParseOk a -> k a s l
+
+> returnP :: Monad m => a -> P m a
+> returnP a = \s l -> return (ParseOk a)
+
+-----------------------------------------------------------------------------
+
+Now we declare the datastructure that we are parsing.
+
+> data Exp  = Let Int String Exp Exp | Exp1 Exp1
+> data Exp1 = Plus Exp1 Term | Minus Exp1 Term | Term Term
+> data Term = Times Term Factor | Div Term Factor | Factor Factor
+> data Factor = Int Int | Var String | Brack Exp
+
+The datastructure for the tokens...
+
+> data Token
+>	= TokenLet
+>	| TokenIn
+>	| TokenInt Int
+>	| TokenVar String
+>	| TokenEq
+>	| TokenPlus
+>	| TokenMinus
+>	| TokenTimes
+>	| TokenDiv
+>	| TokenOB
+>	| TokenCB
+>	| TokenEOF
+
+.. and a simple lexer that returns this datastructure.
+
+> lexer :: Monad m => (Token -> P m a) -> P m a
+> lexer cont s = case s of
+> 	[] -> cont TokenEOF []
+>  	('\n':cs) -> \line -> lexer cont cs (line+1)
+> 	(c:cs)
+>               | isSpace c -> lexer cont cs
+>               | isAlpha c -> lexVar (c:cs)
+>               | isDigit c -> lexNum (c:cs)
+> 	('=':cs) -> cont TokenEq cs
+> 	('+':cs) -> cont TokenPlus cs
+> 	('-':cs) -> cont TokenMinus cs
+> 	('*':cs) -> cont TokenTimes cs
+> 	('/':cs) -> cont TokenDiv cs
+> 	('(':cs) -> cont TokenOB cs
+> 	(')':cs) -> cont TokenCB cs
+>  where
+> 	lexNum cs = cont (TokenInt (read num)) rest
+> 		where (num,rest) = span isDigit cs
+> 	lexVar cs =
+>    	    case span isAlpha cs of
+> 		("let",rest) -> cont TokenLet rest
+> 		("in",rest)  -> cont TokenIn rest
+> 		(var,rest)   -> cont (TokenVar var) rest
+
+> runCalc :: Monad m => String -> m Exp
+> runCalc s =
+>   do
+>     res <- calc s 1
+>     case res of
+>       ParseOk e -> return e
+>       ParseFail s -> error s
+
+-----------------------------------------------------------------------------
+The following functions should be defined for all parsers.
+
+This is the overall type of the parser.
+
+> type Parse m = P m Exp
+> calc :: Monad m => Parse m
+
+The next function is called when a parse error is detected.  It has
+the same type as the top-level parse function.
+
+> happyError :: P m a
+> happyError = \s i -> error (
+>	"Parse error in line " ++ show (i::Int) ++ "\n")
+
+-----------------------------------------------------------------------------
+
+Here we test our parser.
+
+> main =
+>   do
+>     res <- runCalc "1 + 2 + 3"
+>     case res of
+>       (Exp1 (Plus (Plus (Term (Factor (Int 1)))
+>             (Factor (Int 2))) (Factor (Int 3)))) ->
+>         do
+>           res <- runCalc "1 * 2 + 3"
+>           case res of
+>             (Exp1 (Plus (Term (Times (Factor (Int 1)) (Int 2)))
+>                   (Factor (Int 3)))) ->
+>               do
+>                 res <- runCalc "1 + 2 * 3"
+>                 case res of
+>                   (Exp1 (Plus (Term (Factor (Int 1)))
+>                         (Times (Factor (Int 2)) (Int 3)))) ->
+>                     do
+>                       res <- runCalc "let x = 2 in x * (x - 2)"
+>                       case res of
+>                         (Let 1 "x" (Exp1 (Term (Factor (Int 2))))
+>                                    (Exp1 (Term (Times (Factor (Var "x"))
+>                                    (Brack (Exp1 (Minus (Term (Factor (Var "x")))
+>                                    (Factor (Int 2))))))))) ->
+>                           print "Test works\n"
+>                         _ -> quit
+>                   _ -> quit
+>             _ -> quit
+>       _ -> quit
+> quit = print "Test failed\n"
+> }

--- a/tests/typeclass_monad_lexer.y
+++ b/tests/typeclass_monad_lexer.y
@@ -1,0 +1,125 @@
+{
+import Control.Monad.Except
+import Control.Monad.State
+import Control.Monad.Trans
+
+}
+
+%name parse exp
+%tokentype { Token }
+%error { parseError }
+%monad { (MonadIO m) } { Parser m }
+%lexer { lexer } { EOF }
+%token ID { Id _ }
+       NUM { Num _ }
+       PLUS { Plus }
+       MINUS { Minus }
+       TIMES { Times }
+       LPAREN { LParen }
+       RPAREN { RParen }
+
+%%
+
+exp :: { AST }
+    : exp PLUS prod
+      { Sum $1 $3 }
+    | prod
+      { $1 }
+
+prod :: { AST }
+     : prod TIMES neg
+       { Prod $1 $3 }
+     | neg
+       { $1 }
+
+neg :: { AST }
+    : MINUS neg
+      { Neg $2 }
+    | atom
+      { $1 }
+
+atom :: { AST }
+     : ID
+       { let Id str = $1 in Var str }
+     | NUM
+       { let Num n = $1 in Lit n }
+     | LPAREN exp RPAREN
+       { $2 }
+
+{
+
+data Token =
+    Plus
+  | Minus
+  | Times
+  | LParen
+  | RParen
+  | Id String
+  | Num Int
+  | EOF
+    deriving (Eq, Ord, Show)
+
+data AST =
+    Sum AST AST
+  | Prod AST AST
+  | Neg AST
+  | Var String
+  | Lit Int
+    deriving (Eq, Ord)
+
+type Parser m = ExceptT () (Lexer m)
+
+type Lexer m = StateT [Token] m
+
+parseError :: MonadIO m => Token -> Parser m a
+parseError tok =
+  do
+    liftIO (putStrLn ("Parse error at " ++ show tok))
+    throwError ()
+
+lexer :: MonadIO m => (Token -> Parser m a) -> Parser m a
+lexer cont =
+  do
+    toks <- get
+    case toks of
+      [] -> cont EOF
+      first : rest ->
+        do
+          put rest
+          cont first
+
+parse :: (MonadIO m) => Parser m AST
+
+parser :: (MonadIO m) =>
+          [Token]
+       -> m (Maybe AST)
+parser input =
+  let
+    run :: (MonadIO m) =>
+           Lexer m (Maybe AST)
+    run =
+      do
+        res <- runExceptT parse
+        case res of
+          Left () -> return Nothing
+          Right ast -> return (Just ast)
+  in do
+    (out, _) <- runStateT run input
+    return out
+
+main :: IO ()
+main =
+  let
+    input = [Id "x", Plus,
+             Minus, Num 1, Times,
+             LParen, Num 2, Plus, Id "y", RParen]
+    expected = Sum (Var "x") (Prod (Neg (Lit 1)) (Sum (Lit 2) (Var "y")))
+  in do
+    res <- parser input
+    case res of
+      Nothing -> print "Test failed\n"
+      Just actual
+        | expected == actual -> print "Test works\n"
+        | otherwise -> print "Test failed\n"
+
+}


### PR DESCRIPTION
This pull requests causes happy to generate some new signatures that allow typeclasses to be used in monadic parsers.  This makes no changes to actual code; it only generates some signatures.

This patch only generates signature for parsers that combine `%monad` and `%lexer` directives.  There appear to be some non-trivial issues that arise when `%monad` is used without `%lexer`.

This has been verified to work with a complex parser (and in conjunction with the corresponding alex pull request) here:

https://github.com/saltlang/saltlang/blob/typeclass_parser/src/salt/Language/Salt/Surface/Parser.y

The resulting lexer/parser combination operates inside a monad completely described by typeclasses.
