### PR TITLE
Type signature on parameterized rules

### DIFF
--- a/src/ParamRules.hs
+++ b/src/ParamRules.hs
@@ -17,12 +17,13 @@ expand_rules rs = do let (funs,rs1) = split_rules rs
 type RuleName = String
 type Inst     = (RuleName, [RuleName])
 type Funs     = M.Map RuleName Rule
-type Rule1    = (RuleName,[Prod1],Maybe String)
+type Rule1    = (RuleName,[Prod1],Maybe (String, Subst))
 type Prod1    = ([RuleName],String,Int,Maybe String)
 
 inst_name :: Inst -> RuleName
 inst_name (f,[])  = f
-inst_name (f,xs)  = f ++ "(" ++ concat (intersperse "," xs) ++ ")"
+--inst_name (f,xs)  = f ++ "(" ++ concat (intersperse "," xs) ++ ")"
+inst_name (f,xs)  = f ++ "__" ++ concat (intersperse "__" xs) ++ "__"
 
 
 -- | A renaming substitution used when we instantiate a parameterized rule.
@@ -54,7 +55,7 @@ inst_rule :: Rule -> [RuleName] -> M2 Rule1
 inst_rule (x,xs,ps,t) ts  = do s <- build xs ts []
                                ps1 <- lift $ mapM (inst_prod s) ps
                                let y = inst_name (x,ts)
-                               return (y,ps1,t)    -- XXX: type?
+                               return (y,ps1,fmap (\x -> (x,s)) t)
   where build (x':xs') (t':ts') m = build xs' ts' ((x',t'):m)
         build [] [] m  = return m
         build xs' [] _  = err ("Need " ++ show (length xs') ++ " more arguments")


### PR DESCRIPTION
This pull request adds the ability to create type signatures for parameterized rules.  This, along with a slight change to the way that parameterized rule instance names are generated allows parameterized rules to be used with GLR parsers.

It works by substituting the formal parameter names in parameterized rule type signatures with the types associated with the actual parameters.  Only parameter names that start with a lowercase letter are substituted.  Actual parameters that correspond with non-terminals are substituted with the non-terminal's type (which must be defined).  Actual parameters that correspond with terminals are substituted with the token type, which will not work correctly when the terminal uses a `$$` in its token pattern.  For this to work, there would need to be a way to define the type of the `$$`.  A work around would be to define a non-terminal with a single production corresponding to the `$$` terminal, and to use it (and its associated type signature) instead.

In addition, parameterized rule instance names are generated by interleaving (and terminating) the actual parameters with double underscores instead of commas and parentheses so that they form valid data constructor names in the `GSymbol` data type.  Note that string and character actuals are not currently handled, and will generate illegal names if used.  There is a possibility that these auto-generated names could alias, since a non-parameterized non-terminal could be given such a name; however, the fact that the names end with a double underscore makes this unlikely.

For instance, the following grammar:

```happy
{
{-# LANGUAGE FlexibleInstances #-}
}

%tokentype { Token }
%token
  Int   { TokInt }
  Ident { TokIdent }

%%

top :: { ([Token], [Token], Maybe Token) }
    : many(Int) many1(Ident) opt(Int) { ($1, $2, $3) }

opt(p) :: { Maybe p }
       : p { Just $1 }
       | {- empty -} { Nothing }

many(p) :: { [p] }
	: many1rev(p) { reverse $1 }
	| {- empty -} { [] }

many1(p) :: { [p] }
	 : many1rev(p) { reverse $1 }

many1rev(p) :: { [p] }
	    : p { [$1] }
	    | many1rev(p) p { ($2:$1) }

{
data Token = TokInt | TokIdent
  deriving ( Eq, Ord, Show )
}
```
 Generates the following definitions for `GSymbol` and `GSem` when run with --glr --decode:

```haskell
data GSymbol = HappyEOF | HappyTok {-!Int-} (Token) | G_top 
 | G_many__Int__ 
 | G_many1__Ident__ 
 | G_opt__Int__ 
 | G_many1rev__Ident__ 
 | G_many1rev__Int__ 
   deriving (Show,Eq,Ord)

data GSem
 = NoSem
 | SemTok (Token)
 | Sem_0 ([(Token)] -> [(Token)] -> Maybe (Token) -> ([Token], [Token], Maybe Token)) 
 | Sem_1 ([(Token)] -> [(Token)]) 
 | Sem_2 ([(Token)]) 
 | Sem_3 (Token -> Maybe (Token)) 
 | Sem_4 (Maybe (Token)) 
 | Sem_5 (Token -> [(Token)]) 
 | Sem_6 ([(Token)] -> Token -> [(Token)]) 
```
