### PR TITLE
Fix ProduceCode.hs for GHC 7.10.x

### DIFF
--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -401,7 +401,24 @@ The token conversion function.
 >             -- so we must not pass it to happyError'
 
 >       Just (lexer'',eof') ->
->         str "happyNewToken action sts stk\n\t= "
+>       case (target, ghc) of
+>          (TargetHaskell, True) ->
+>                 str "happyNewToken :: (Happy_GHC_Exts.Int#\n"
+>               . str "                   -> Happy_GHC_Exts.Int#\n"
+>               . str "                   -> Token\n"
+>               . str "                   -> HappyState Token (t -> [Char] -> Int -> ParseResult a)\n"
+>               . str "                   -> [HappyState Token (t -> [Char] -> Int -> ParseResult a)]\n"
+>               . str "                   -> t\n"
+>               . str "                   -> [Char]\n"
+>               . str "                   -> Int\n"
+>               . str "                   -> ParseResult a)\n"
+>               . str "                 -> [HappyState Token (t -> [Char] -> Int -> ParseResult a)]\n"
+>               . str "                 -> t\n"
+>               . str "                 -> [Char]\n"
+>               . str "                 -> Int\n"
+>               . str "                 -> ParseResult a\n"
+>          _ -> id
+>       . str "happyNewToken action sts stk\n\t= "
 >       . str lexer''
 >       . str "(\\tk -> "
 >       . str "\n\tlet cont i = "


### PR DESCRIPTION
Adding the type signature takes care of this error:

```
../dist/build/happy/happy --strict --template=.. -g monad002.ly -o monad002.g.hs
ghc -hide-all-packages -package base -package array -package mtl -Werror -fforce-recomp  monad002.g.hs -o monad002.g.bin
[1 of 1] Compiling Main             ( monad002.g.hs, monad002.g.o )

monad002.g.hs:311:22:
    Couldn't match kind ‘*’ with ‘#’
    When matching types
      t0 :: *
      Happy_GHC_Exts.Int# :: #
```

And 'cabal test' pass. Tested with GHC 7.8.4 too.

Signed-off-by: Dan Aloni <dan@kernelim.com>