### PR TITLE
GenericTemplate.hs: workaround GHC 7.6 type checking failure

### DIFF
--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -151,12 +151,13 @@ indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif
 
 
-readArrayBit arr bit =
-    Bits.testBit IBOX(indexShortOffAddr arr (unbox_int $ bit `div` 16)) (bit `mod` 16)
 #ifdef HAPPY_GHC
+readArrayBit arr bit =
+    Bits.testBit IBOX(indexShortOffAddr arr ((unbox_int bit) `Happy_GHC_Exts.iShiftRA#` 4#)) (bit `mod` 16)
   where unbox_int (Happy_GHC_Exts.I# x) = x
 #else
-  where unbox_int = id
+readArrayBit arr bit =
+    Bits.testBit IBOX(indexShortOffAddr arr (bit `div` 16)) (bit `mod` 16)
 #endif
 
 #ifdef HAPPY_GHC


### PR DESCRIPTION
Even with an exact type signature for `unbox_int `and `indexShortOffAddr` GHC 7.6 fails to realize the type for the second parameter of indexShortOffAddr which needs to be of unboxed kind '#' instead
of boxed '*'.

```
    Couldn't match kind `#' against `*'
    In the second argument of `indexShortOffAddr', namely
      `(unbox_int $ bit `div` 16)'
```

It's probably due to `div`. Figured out we can use unboxed right shift instead, to get it straight.

Tested with GHC 7.6.3, GHC 7.8.4, and GHC 7.10.3.

Signed-off-by: Dan Aloni <dan@kernelim.com>