### PR TITLE
Fix broken command line options.

### DIFF
--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -164,14 +164,32 @@ Report any conflicts in the grammar.
 
 Print out the info file.
 
+>       getInfoFileName name cli                >>= \info_filename ->
+>       let info = genInfoFile
+>                       (map fst sets)
+>                       g
+>                       action
+>                       goto
+>                       (token_specs g)
+>                       conflictArray
+>                       fl_name
+>                       unused_rules
+>                       unused_terminals
+>       in
+>       (case info_filename of
+>               Just s  -> writeFile s info
+>               Nothing -> return ())                   >>
+
+
+Pretty print the grammar.
+
 >       getPrettyFileName name cli                >>= \info_filename ->
 >       (let out = render (ppAbsSyn abssyn)
 >        in
 >        case info_filename of
->          Just s  -> writeFile s out
->          Nothing -> putStrLn out) >>
+>          Just s   -> writeFile s out
+>          Nothing  -> return ()) >>
 
-Pretty print the grammar.
 
 
 


### PR DESCRIPTION
The commit adding the pretty printing functionality accidentally
broke the `-i` flag.   `-p` was also broken, in that it would print
to `stdout` all the time.

Should be fixed now, sorry for the breakage.