### PR TITLE
Clean up warnings from pretty-grammar feature

### DIFF
--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -183,10 +183,10 @@ Print out the info file.
 
 Pretty print the grammar.
 
->       getPrettyFileName name cli                >>= \info_filename ->
+>       getPrettyFileName name cli                >>= \pretty_filename ->
 >       (let out = render (ppAbsSyn abssyn)
 >        in
->        case info_filename of
+>        case pretty_filename of
 >          Just s   -> writeFile s out
 >          Nothing  -> return ()) >>
 

--- a/src/PrettyGrammar.hs
+++ b/src/PrettyGrammar.hs
@@ -1,7 +1,6 @@
 module PrettyGrammar where
 
 import AbsSyn
-import Data.List(intersperse)
 
 render :: Doc -> String
 render = maybe "" ($ "")
@@ -20,8 +19,8 @@ ppDirective dir =
   prec x xs = text x <+> hsep (map text xs)
 
 ppRule :: Rule -> Doc
-ppRule (name,params,prods,_) = text name
-                            $$ vcat (zipWith (<+>) starts (map ppProd prods))
+ppRule (name,_,prods,_) = text name
+                       $$ vcat (zipWith (<+>) starts (map ppProd prods))
   where
   starts = text "  :" : repeat (text "  |")
 


### PR DESCRIPTION
This should be functionally equivalent to the previous version, it just removes an unused import, an unused variable, and a shadowed variable.