### PR TITLE
Catch up with cabal modifications on hackage

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -120,6 +120,12 @@ extra-source-files:
 	tests/precedence002.y
 	tests/test_rules.y
 
+custom-setup
+  setup-depends: Cabal <2.1,
+                 base <5,
+                 directory <1.4,
+                 filepath <1.5
+
 source-repository head
   type:     git
   location: https://github.com/simonmar/happy.git
@@ -133,7 +139,7 @@ executable happy
 
   build-depends: base < 5,
                  array,
-                 containers,
+                 containers >= 0.4.2,
                  mtl >= 1.0
 
   extensions: CPP, MagicHash, FlexibleContexts


### PR DESCRIPTION
See http://hackage.haskell.org/package/happy-1.19.5/revisions/

Stil couldn't get it to build with:

```
$ stack init
$ stack build --nix
mtl-2.2.1: configure
mtl-2.2.1: build
mtl-2.2.1: copy/register
happy-1.19.6: configure (exe)
[1 of 2] Compiling Main             ( /home/ielectric/dev/happy/Setup.lhs, /home/ielectric/dev/happy/.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/setup/Main.o )
[2 of 2] Compiling StackSetupShim   ( /home/ielectric/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /home/ielectric/dev/happy/.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/setup/StackSetupShim.o )
Linking /home/ielectric/dev/happy/.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/setup/setup ...
Configuring happy-1.19.6...
happy-1.19.6: build (exe)
Preprocessing executable 'happy' for happy-1.19.6...
setup: The program 'happy' is required but it could not be found
Completed 2 action(s).

--  While building package happy-1.19.6 using:
      /home/ielectric/dev/happy/.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0/setup/setup --builddir=.stack-work/dist/x86_64-linux-nix/Cabal-1.24.2.0 build exe:happy --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
```