### PR TITLE
'happyNewToken' now uses the right token type

### DIFF
--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -429,18 +429,18 @@ The token conversion function.
 >       case (target, ghc) of
 >          (TargetHaskell, True) ->
 >             let pcont = str monad_context
->                 pty = str monad_tycon  in
+>                 pty = str monad_tycon in
 >                 str "happyNewToken :: " . pcont . str " => "
 >               . str "(Happy_GHC_Exts.Int#\n"
 >               . str "                   -> Happy_GHC_Exts.Int#\n"
->               . str "                   -> Token\n"
->               . str "                   -> HappyState Token (t -> "
+>               . str "                   -> " . token . str "\n"
+>               . str "                   -> HappyState " . token . str " (t -> "
 >               . pty . str " a)\n"
->               . str "                   -> [HappyState Token (t -> "
+>               . str "                   -> [HappyState " . token . str " (t -> "
 >               . pty . str " a)]\n"
 >               . str "                   -> t\n"
 >               . str "                   -> " . pty . str " a)\n"
->               . str "                 -> [HappyState Token (t -> "
+>               . str "                 -> [HappyState " . token . str " (t -> "
 >               . pty . str " a)]\n"
 >               . str "                 -> t\n"
 >               . str "                 -> " . pty . str " a\n"


### PR DESCRIPTION
This should fix #91.

This bug can be triggered by compiling the generated code on any grammar that

  * uses `%tokentype` that is _not_ just `Token` (try something like `Token1`)
  * makes use of `%lexer`
  * is compiled using `-g` 