### PR TITLE
Add types to help GHC infer kind in `happyMonad2Reduce`

### DIFF
--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -242,6 +242,7 @@ happyMonad2Reduce k nt fn j tk st sts stk =
              off_i = PLUS(off,nt)
              new_state = indexShortOffAddr happyTable off_i
 #else
+             _ = nt :: FAST_INT
              new_state = action
 #endif
           in

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ endif
 
 TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
-	bogus-token.y bug002.y Partial.ly bug003.y \
+	bogus-token.y bug002.y Partial.ly bug003.y bug004.y \
 	AttrGrammar001.y AttrGrammar002.y \
 	test_rules.y monaderror.y monaderror-explist.y \
 	typeclass_monad001.y typeclass_monad002.ly typeclass_monad_lexer.y

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ endif
 
 TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
-	bogus-token.y bug002.y Partial.ly bug003.y bug004.y \
+	bogus-token.y bug002.y Partial.ly issue91.y issue95.y \
 	AttrGrammar001.y AttrGrammar002.y \
 	test_rules.y monaderror.y monaderror-explist.y \
 	typeclass_monad001.y typeclass_monad002.ly typeclass_monad_lexer.y

--- a/tests/bug004.y
+++ b/tests/bug004.y
@@ -1,0 +1,34 @@
+%name parse prod
+
+%tokentype { Token }
+
+%monad { P } { bindP } { returnP }
+%error { error "parse error" }
+%lexer { lexer } { EOF }
+
+%token
+  IDENT  { Identifier $$ }
+
+%%
+
+prod :: { () }
+  : IDENT {%% \_ -> returnP () }
+
+{
+
+data Token = EOF | Identifier String
+
+type P a = String -> (a, String)
+
+bindP :: P a -> (a -> P b) -> P b
+bindP p f s = let (x,s') = p s in f x s'
+
+returnP :: a -> P a
+returnP = (,)
+
+lexer :: (Token -> P a) -> P a
+lexer cont s = cont (case s of { "" -> EOF; _ -> Identifier s }) ""
+
+main = pure ()
+
+}

--- a/tests/issue91.y
+++ b/tests/issue91.y
@@ -1,3 +1,4 @@
+-- See <https://github.com/simonmar/happy/issues/91> for more information
 %name parse prod
 
 %tokentype { Tok }

--- a/tests/issue95.y
+++ b/tests/issue95.y
@@ -1,3 +1,4 @@
+-- See <https://github.com/simonmar/happy/issues/95> for more information
 %name parse prod
 
 %tokentype { Token }


### PR DESCRIPTION
The type annotation on `nt` is only needed in the case that `-a` is not enabled. When `-a` is enabled, the type of `nt` is constrained by `PLUS(off,nt)`.

I also added a regression test case (which would previously have failed with just `-gc` enabled). As before, I can't run the test suite automatically, so if Travis fails I'll see what is up.

This fixes #95.