### PR TITLE
Happy overflow bug

### DIFF
--- a/src/Grammar.lhs
+++ b/src/Grammar.lhs
@@ -32,12 +32,6 @@ Here is our mid-section datatype
 
 > import Control.Monad.Writer
 
-#ifdef DEBUG
-
-> import System.IOExts
-
-#endif
-
 > type Name = Int
 
 > type Production = (Name,[Name],(String,[Int]),Priority)

--- a/src/LALR.lhs
+++ b/src/LALR.lhs
@@ -35,7 +35,15 @@ Generation of LALR parsing tables.
 This means rule $a$, with dot at $b$ (all starting at 0)
 
 > data Lr0Item = Lr0 {-#UNPACK#-}!Int {-#UNPACK#-}!Int                  -- (rule, dot)
->       deriving (Eq,Ord)
+>       deriving (Eq,Ord
+
+#ifdef DEBUG
+
+>       ,Show
+
+#endif
+
+>       )
 
 > data Lr1Item = Lr1 {-#UNPACK#-}!Int {-#UNPACK#-}!Int NameSet  -- (rule, dot, lookahead)
 > type RuleList = [Lr0Item]

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -676,6 +676,10 @@ action array indexed by (terminal * last_state) + state
 >               . shows (n_states) . str ") (["
 >           . interleave' "," (map shows goto_offs)
 >           . str "\n\t])\n\n"
+>           
+>           . str "happyMinOffset :: Int\n"
+>           . str "happyMinOffset = " . str (show (minBound :: Int))
+>           . str "\n\n"  --"
 >
 >           . str "happyDefActions :: Happy_Data_Array.Array Int Int\n"
 >           . str "happyDefActions = Happy_Data_Array.listArray (0,"

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -90,6 +90,9 @@ Produce the complete output file.
 >       -- fix, others not so easy, and others would require GHC version
 >       -- #ifdefs.  For now I'm just disabling all of them.
 >
+>    intMaybeHash | ghc       = str "Happy_GHC_Exts.Int#"
+>                 | otherwise = str "Int"
+>
 >    top_opts = nowarn_opts .
 >      case top_options of
 >          "" -> str ""
@@ -219,9 +222,7 @@ based parsers -- types aren't as important there).
 
 >     | otherwise = id
 
->       where intMaybeHash | ghc       = str "Happy_GHC_Exts.Int#"
->                          | otherwise = str "Int"
->             tokens =
+>       where tokens =
 >               case lexer' of
 >                       Nothing -> char '[' . token . str "] -> "
 >                       Just _ -> id
@@ -347,8 +348,6 @@ happyMonadReduce to get polymorphic recursion.  Sigh.
 >                           str_tyvars = str (unwords all_tyvars)
 >                           happyAbsSyn = str "(HappyAbsSyn "
 >                                         . str_tyvars . str ")"
->                           intMaybeHash | ghc       = str "Happy_GHC_Exts.Int#"
->                                        | otherwise = str "Int"
 >                           tysig = case lexer' of
 >                             Nothing -> id
 >                             _ | target == TargetArrayBased ->
@@ -646,6 +645,10 @@ action array indexed by (terminal * last_state) + state
 >           . str (hexChars goto_offs)
 >           . str "\"#\n\n"  --"
 >
+>           . str "happyMinOffset :: Int\n"
+>           . str "happyMinOffset = " . str (show min_off)
+>           . str "\n\n"  --"
+>
 >           . str "happyDefActions :: HappyAddr\n"
 >           . str "happyDefActions = HappyA# \"" --"
 >           . str (hexChars defaults)
@@ -710,7 +713,7 @@ action array indexed by (terminal * last_state) + state
 >    n_terminals = length terms
 >    n_nonterminals = length nonterms - n_starts -- lose %starts
 >
->    (act_offs,goto_offs,table,defaults,check,explist)
+>    (act_offs,goto_offs,table,defaults,check,explist,min_off)
 >       = mkTables action goto first_nonterm' fst_term
 >               n_terminals n_nonterminals n_starts (bounds token_names')
 >
@@ -836,8 +839,6 @@ MonadStuff:
 >                  all_tyvars = [ 't':show n | (n, Nothing) <- assocs nt_types ]
 >                  str_tyvars = str (unwords all_tyvars)
 >                  happyAbsSyn = str "(HappyAbsSyn " . str_tyvars . str ")"
->                  intMaybeHash | ghc       = str "Happy_GHC_Exts.Int#"
->                               | otherwise = str "Int"
 >                  happyParseSig
 >                    | target == TargetArrayBased =
 >                      str "happyParse :: " . pcont . str " => " . intMaybeHash
@@ -1091,12 +1092,13 @@ See notes under "Action Tables" above for some subtleties in this function.
 
 > mkTables
 >        :: ActionTable -> GotoTable -> Name -> Int -> Int -> Int -> Int -> (Int, Int) ->
->        ([Int]         -- happyActOffsets
->        ,[Int]         -- happyGotoOffsets
->        ,[Int]         -- happyTable
->        ,[Int]         -- happyDefAction
->        ,[Int]         -- happyCheck
->        ,[Int]         -- happyExpList
+>        ( [Int]         -- happyActOffsets
+>        , [Int]         -- happyGotoOffsets
+>        , [Int]         -- happyTable
+>        , [Int]         -- happyDefAction
+>        , [Int]         -- happyCheck
+>        , [Int]         -- happyExpList
+>        , Int           -- happyMinOffset
 >        )
 >
 > mkTables action goto first_nonterm' fst_term
@@ -1104,15 +1106,16 @@ See notes under "Action Tables" above for some subtleties in this function.
 >               token_names_bound
 >
 >  = ( elems act_offs,
->      elems goto_offs,
->      take max_off (elems table),
->      def_actions,
->      take max_off (elems check),
->      elems explist
->   )
+>    , elems goto_offs,
+>    , take max_off (elems table),
+>    , def_actions,
+>    , take max_off (elems check),
+>    , elems explist,
+>    , min_off
+>    )
 >  where
 >
->        (table,check,act_offs,goto_offs,explist,max_off)
+>        (table,check,act_offs,goto_offs,explist,min_off,max_off)
 >                = runST (genTables (length actions)
 >                         max_token token_names_bound
 >                         sorted_actions explist_actions)
@@ -1180,12 +1183,13 @@ See notes under "Action Tables" above for some subtleties in this function.
 >                | otherwise = GT
 
 > data ActionOrGoto = ActionEntry | GotoEntry
-> type TableEntry = (ActionOrGoto,
->                       Int{-stateno-},
->                       Int{-default-},
->                       Int{-width-},
->                       Int{-tally-},
->                       [(Int,Int)])
+> type TableEntry = ( ActionOrGoto
+>                   , Int {-stateno-}
+>                   , Int {-default-}
+>                   , Int {-width-}
+>                   , Int {-tally-}
+>                   , [(Int,Int)]
+>                   )
 
 > genTables
 >        :: Int                         -- number of actions
@@ -1193,13 +1197,14 @@ See notes under "Action Tables" above for some subtleties in this function.
 >        -> (Int, Int)                  -- token names bounds
 >        -> [TableEntry]                -- entries for the table
 >        -> [(Int, [Int])]              -- expected tokens lists
->        -> ST s (UArray Int Int,       -- table
->                 UArray Int Int,       -- check
->                 UArray Int Int,       -- action offsets
->                 UArray Int Int,       -- goto offsets
->                 UArray Int Int,       -- expected tokens list
->                 Int                   -- highest offset in table
->           )
+>        -> ST s ( UArray Int Int       -- table
+>                , UArray Int Int       -- check
+>                , UArray Int Int       -- action offsets
+>                , UArray Int Int       -- goto offsets
+>                , UArray Int Int       -- expected tokens list
+>                , Int                  -- lowest offset in table
+>                , Int                  -- highest offset in table
+>                )
 >
 > genTables n_actions max_token token_names_bound entries explist = do
 >
@@ -1210,15 +1215,15 @@ See notes under "Action Tables" above for some subtleties in this function.
 >   off_arr    <- newArray (-max_token, mAX_TABLE_SIZE) 0
 >   exp_array  <- newArray (0, (n_actions * n_token_names + 15) `div` 16) 0
 >
->   max_off <- genTables' table check act_offs goto_offs off_arr exp_array entries
->                       explist max_token n_token_names
+>   (min_off,max_off) <- genTables' table check act_offs goto_offs off_arr exp_array entries
+>                          explist max_token n_token_names
 >
 >   table'     <- freeze table
 >   check'     <- freeze check
 >   act_offs'  <- freeze act_offs
 >   goto_offs' <- freeze goto_offs
 >   exp_array' <- freeze exp_array
->   return (table',check',act_offs',goto_offs',exp_array',max_off+1)
+>   return (table',check',act_offs',goto_offs',exp_array',min_off,max_off+1)
 
 >   where
 >        n_states = n_actions - 1
@@ -1238,19 +1243,19 @@ See notes under "Action Tables" above for some subtleties in this function.
 >        -> [(Int, [Int])]              -- expected tokens lists
 >        -> Int                         -- maximum token no.
 >        -> Int                         -- number of token names
->        -> ST s Int                    -- highest offset in table
+>        -> ST s (Int,Int)              -- lowest and highest offsets in table
 >
 > genTables' table check act_offs goto_offs off_arr exp_array entries
 >            explist max_token n_token_names
->       = fill_exp_array >> fit_all entries 0 1
+>       = fill_exp_array >> fit_all entries 0 0 1
 >   where
 >
->        fit_all [] max_off _ = return max_off
->        fit_all (s:ss) max_off fst_zero = do
->          (off, new_max_off, new_fst_zero) <- fit s max_off fst_zero
+>        fit_all [] min_off max_off _ = return (min_off, max_off)
+>        fit_all (s:ss) min_off max_off fst_zero = do
+>          (off, new_min_off, new_max_off, new_fst_zero) <- fit s min_off max_off fst_zero
 >          ss' <- same_states s ss off
 >          writeArray off_arr off 1
->          fit_all ss' new_max_off new_fst_zero
+>          fit_all ss' new_min_off new_max_off new_fst_zero
 >
 >        fill_exp_array =
 >          forM_ explist $ \(state, tokens) ->
@@ -1276,16 +1281,19 @@ See notes under "Action Tables" above for some subtleties in this function.
 >        -- fit a vector into the table.  Return the offset of the vector,
 >        -- the maximum offset used in the table, and the offset of the first
 >        -- entry in the table (used to speed up the lookups a bit).
->        fit (_,_,_,_,_,[]) max_off fst_zero = return (0,max_off,fst_zero)
+>        fit (_,_,_,_,_,[]) min_off max_off fst_zero = return (0,min_off,max_off,fst_zero)
 >
 >        fit (act_or_goto, state_no, _deflt, _, _, state@((t,_):_))
->           max_off fst_zero = do
+>           min_off max_off fst_zero = do
 >                -- start at offset 1 in the table: all the empty states
 >                -- (states with just a default reduction) are mapped to
 >                -- offset zero.
 >          off <- findFreeOffset (-t+fst_zero) check off_arr state
->          let new_max_off | furthest_right > max_off = furthest_right
+>          let new_min_off | furthest_left  < min_off = furthest_left
+>                          | otherwise                = min_off
+>              new_max_off | furthest_right > max_off = furthest_right
 >                          | otherwise                = max_off
+>              furthest_left  = off
 >              furthest_right = off + max_token
 >
 >          -- trace ("fit: state " ++ show state_no ++ ", off " ++ show off ++ ", elems " ++ show state) $ do
@@ -1293,7 +1301,7 @@ See notes under "Action Tables" above for some subtleties in this function.
 >          writeArray (which_off act_or_goto) state_no off
 >          addState off table check state
 >          new_fst_zero <- findFstFreeSlot check fst_zero
->          return (off, new_max_off, new_fst_zero)
+>          return (off, new_min_off, new_max_off, new_fst_zero)
 
 When looking for a free offest in the table, we use the 'check' table
 rather than the main table.  The check table starts off with (-1) in

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -1105,12 +1105,12 @@ See notes under "Action Tables" above for some subtleties in this function.
 >               n_terminals n_nonterminals n_starts
 >               token_names_bound
 >
->  = ( elems act_offs,
->    , elems goto_offs,
->    , take max_off (elems table),
->    , def_actions,
->    , take max_off (elems check),
->    , elems explist,
+>  = ( elems act_offs
+>    , elems goto_offs
+>    , take max_off (elems table)
+>    , def_actions
+>    , take max_off (elems check)
+>    , elems explist
 >    , min_off
 >    )
 >  where

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -128,7 +128,8 @@ happyDoAction i tk st
                                      happyShift new_state i tk st
                                      where new_state = MINUS(n,(ILIT(1) :: FAST_INT))
    where off    = indexShortOffAddr happyActOffsets st
-         off_i  = PLUS(off,i)
+         !IBOX(min_off) = happyMinOffset
+         off_i = if LT(off, min_off) then PLUS(off, PLUS(i, ILIT(65536))) else PLUS(off, i)
          check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
                   then EQ(indexShortOffAddr happyCheck off_i, i)
                   else False
@@ -139,13 +140,7 @@ happyDoAction i tk st
 #endif /* HAPPY_ARRAY */
 
 #ifdef HAPPY_GHC
-indexShortOffAddr (HappyA# arr) off = i_adjusted
-  where
-        !(_, Happy_GHC_Exts.I# n_rules) = Happy_Data_Array.bounds happyReduceArr
-        i = Happy_GHC_Exts.indexInt16OffAddr# arr off
-        i_adjusted = if Happy_GHC_Exts.isTrue# (Happy_GHC_Exts.negateInt# n_rules Happy_GHC_Exts.>=# i)
-                       then i Happy_GHC_Exts.+# 65536#
-                       else i
+indexShortOffAddr (HappyA# arr) off = Happy_GHC_Exts.indexInt16OffAddr# arr off
 #else
 indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif
@@ -239,7 +234,8 @@ happyMonad2Reduce k nt fn j tk st sts stk =
          let drop_stk = happyDropStk k stk
 #if defined(HAPPY_ARRAY)
              off = indexShortOffAddr happyGotoOffsets st1
-             off_i = PLUS(off,nt)
+             !IBOX(min_off) = happyMinOffset
+             off_i = if LT(off, min_off) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
              new_state = indexShortOffAddr happyTable off_i
 #else
              _ = nt :: FAST_INT
@@ -262,7 +258,8 @@ happyGoto nt j tk st =
    DEBUG_TRACE(", goto state " ++ show IBOX(new_state) ++ "\n")
    happyDoAction j tk new_state
    where off = indexShortOffAddr happyGotoOffsets st
-         off_i = PLUS(off,nt)
+         !IBOX(min_off) = happyMinOffset
+         off_i = if LT(off, min_off) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
          new_state = indexShortOffAddr happyTable off_i
 #else
 happyGoto action j tk st = action j j tk (HappyState action)

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -139,13 +139,13 @@ happyDoAction i tk st
 #endif /* HAPPY_ARRAY */
 
 #ifdef HAPPY_GHC
-indexShortOffAddr (HappyA# arr) off =
-        Happy_GHC_Exts.narrow16Int# i
+indexShortOffAddr (HappyA# arr) off = i_adjusted
   where
-        i = Happy_GHC_Exts.word2Int# (Happy_GHC_Exts.or# (Happy_GHC_Exts.uncheckedShiftL# high 8#) low)
-        high = Happy_GHC_Exts.int2Word# (Happy_GHC_Exts.ord# (Happy_GHC_Exts.indexCharOffAddr# arr (off' Happy_GHC_Exts.+# 1#)))
-        low  = Happy_GHC_Exts.int2Word# (Happy_GHC_Exts.ord# (Happy_GHC_Exts.indexCharOffAddr# arr off'))
-        off' = off Happy_GHC_Exts.*# 2#
+        !(_, Happy_GHC_Exts.I# n_rules) = Happy_Data_Array.bounds happyReduceArr
+        i = Happy_GHC_Exts.indexInt16OffAddr# arr off
+        i_adjusted = if Happy_GHC_Exts.isTrue# (Happy_GHC_Exts.negateInt# n_rules Happy_GHC_Exts.>=# i)
+                       then i Happy_GHC_Exts.+# 65536#
+                       else i
 #else
 indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -128,8 +128,7 @@ happyDoAction i tk st
                                      happyShift new_state i tk st
                                      where new_state = MINUS(n,(ILIT(1) :: FAST_INT))
    where off    = indexShortOffAddr happyActOffsets st
-         !IBOX(min_off) = happyMinOffset
-         off_i = if LT(off, min_off) then PLUS(off, PLUS(i, ILIT(65536))) else PLUS(off, i)
+         off_i = if LT(off, (unbox_int happyMinOffset)) then PLUS(off, PLUS(i, ILIT(65536))) else PLUS(off, i)
          check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
                   then EQ(indexShortOffAddr happyCheck off_i, i)
                   else False
@@ -145,11 +144,11 @@ indexShortOffAddr (HappyA# arr) off = Happy_GHC_Exts.indexInt16OffAddr# arr off
 indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif
 
+unbox_int IBOX(x) = x
 
 #ifdef HAPPY_GHC
 readArrayBit arr bit =
     Bits.testBit IBOX(indexShortOffAddr arr ((unbox_int bit) `Happy_GHC_Exts.iShiftRA#` 4#)) (bit `mod` 16)
-  where unbox_int (Happy_GHC_Exts.I# x) = x
 #else
 readArrayBit arr bit =
     Bits.testBit IBOX(indexShortOffAddr arr (bit `div` 16)) (bit `mod` 16)
@@ -234,8 +233,7 @@ happyMonad2Reduce k nt fn j tk st sts stk =
          let drop_stk = happyDropStk k stk
 #if defined(HAPPY_ARRAY)
              off = indexShortOffAddr happyGotoOffsets st1
-             !IBOX(min_off) = happyMinOffset
-             off_i = if LT(off, min_off) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
+             off_i = if LT(off, (unbox_int happyMinOffset)) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
              new_state = indexShortOffAddr happyTable off_i
 #else
              _ = nt :: FAST_INT
@@ -258,8 +256,7 @@ happyGoto nt j tk st =
    DEBUG_TRACE(", goto state " ++ show IBOX(new_state) ++ "\n")
    happyDoAction j tk new_state
    where off = indexShortOffAddr happyGotoOffsets st
-         !IBOX(min_off) = happyMinOffset
-         off_i = if LT(off, min_off) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
+         off_i = if LT(off, (unbox_int happyMinOffset)) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
          new_state = indexShortOffAddr happyTable off_i
 #else
 happyGoto action j tk st = action j j tk (HappyState action)

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -139,7 +139,13 @@ happyDoAction i tk st
 #endif /* HAPPY_ARRAY */
 
 #ifdef HAPPY_GHC
-indexShortOffAddr (HappyA# arr) off = Happy_GHC_Exts.indexInt16OffAddr# arr off
+indexShortOffAddr (HappyA# arr) off =
+        Happy_GHC_Exts.narrow16Int# i
+  where
+        i = Happy_GHC_Exts.word2Int# (Happy_GHC_Exts.or# (Happy_GHC_Exts.uncheckedShiftL# high 8#) low)
+        high = Happy_GHC_Exts.int2Word# (Happy_GHC_Exts.ord# (Happy_GHC_Exts.indexCharOffAddr# arr (off' Happy_GHC_Exts.+# 1#)))
+        low  = Happy_GHC_Exts.int2Word# (Happy_GHC_Exts.ord# (Happy_GHC_Exts.indexCharOffAddr# arr off'))
+        off' = off Happy_GHC_Exts.*# 2#
 #else
 indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -242,6 +242,7 @@ happyMonad2Reduce k nt fn j tk st sts stk =
              off_i = PLUS(off,nt)
              new_state = indexShortOffAddr happyTable off_i
 #else
+             _ = nt :: FAST_INT
              new_state = action
 #endif
           in

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ endif
 
 TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
-	bogus-token.y bug002.y Partial.ly bug003.y \
+	bogus-token.y bug002.y Partial.ly bug003.y bug004.y \
 	AttrGrammar001.y AttrGrammar002.y \
 	test_rules.y monaderror.y monaderror-explist.y \
 	typeclass_monad001.y typeclass_monad002.ly typeclass_monad_lexer.y

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ endif
 
 TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
-	bogus-token.y bug002.y Partial.ly bug003.y bug004.y \
+	bogus-token.y bug002.y Partial.ly issue91.y issue95.y \
 	AttrGrammar001.y AttrGrammar002.y \
 	test_rules.y monaderror.y monaderror-explist.y \
 	typeclass_monad001.y typeclass_monad002.ly typeclass_monad_lexer.y

--- a/tests/bug004.y
+++ b/tests/bug004.y
@@ -1,0 +1,34 @@
+%name parse prod
+
+%tokentype { Token }
+
+%monad { P } { bindP } { returnP }
+%error { error "parse error" }
+%lexer { lexer } { EOF }
+
+%token
+  IDENT  { Identifier $$ }
+
+%%
+
+prod :: { () }
+  : IDENT {%% \_ -> returnP () }
+
+{
+
+data Token = EOF | Identifier String
+
+type P a = String -> (a, String)
+
+bindP :: P a -> (a -> P b) -> P b
+bindP p f s = let (x,s') = p s in f x s'
+
+returnP :: a -> P a
+returnP = (,)
+
+lexer :: (Token -> P a) -> P a
+lexer cont s = cont (case s of { "" -> EOF; _ -> Identifier s }) ""
+
+main = pure ()
+
+}

--- a/tests/issue91.y
+++ b/tests/issue91.y
@@ -1,3 +1,4 @@
+-- See <https://github.com/simonmar/happy/issues/91> for more information
 %name parse prod
 
 %tokentype { Tok }

--- a/tests/issue95.y
+++ b/tests/issue95.y
@@ -1,3 +1,4 @@
+-- See <https://github.com/simonmar/happy/issues/95> for more information
 %name parse prod
 
 %tokentype { Token }


### PR DESCRIPTION
This fixes #93. In a nutshell:

My `happyTable`/`happyCheck` have over `2^15` entries in them. That isn't a problem by itself, if it weren't for the fact that `happyActOffsets`/`happyGotoOffsets` store indices pointing into `happyTable` in signed 16 bit numbers. Then, the issue is that the indices that are being written into `happyActOffsets` sometimes get too big. When that happens, they wrap around to the vicinity of -32000.

The fix is simple: keep track of the smallest value in `happyActOffsets`/`happyGotoOffsets`. Then, when reading values back out of these arrays, we check if the value read is smaller than what is supposed to be the smallest value. If it is, we know that there was an accidental overflow (and we add `2^16` to the value we got out).

This lets us have `happyTable`/`happyCheck` tables with a little under 2^16 entries - double what we currently have and with no extra space cost. (And enough to fix my [project](https://github.com/harpocrates/language-rust).)