### PR TITLE
Support larger offset tables

### DIFF
--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -128,7 +128,7 @@ happyDoAction i tk st
                                      happyShift new_state i tk st
                                      where new_state = MINUS(n,(ILIT(1) :: FAST_INT))
    where off    = indexShortOffAddr happyActOffsets st
-         off_i  = PLUS(off,i)
+         off_i  = if LT(off, (unbox_int happyMinOffset)) then PLUS(off, PLUS(i, ILIT(65536))) else PLUS(off, i)
          check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
                   then EQ(indexShortOffAddr happyCheck off_i, i)
                   else False
@@ -150,11 +150,11 @@ indexShortOffAddr (HappyA# arr) off =
 indexShortOffAddr arr off = arr Happy_Data_Array.! off
 #endif
 
+unbox_int IBOX(x) = x
 
 #ifdef HAPPY_GHC
 readArrayBit arr bit =
     Bits.testBit IBOX(indexShortOffAddr arr ((unbox_int bit) `Happy_GHC_Exts.iShiftRA#` 4#)) (bit `mod` 16)
-  where unbox_int (Happy_GHC_Exts.I# x) = x
 #else
 readArrayBit arr bit =
     Bits.testBit IBOX(indexShortOffAddr arr (bit `div` 16)) (bit `mod` 16)
@@ -239,7 +239,7 @@ happyMonad2Reduce k nt fn j tk st sts stk =
          let drop_stk = happyDropStk k stk
 #if defined(HAPPY_ARRAY)
              off = indexShortOffAddr happyGotoOffsets st1
-             off_i = PLUS(off,nt)
+             off_i = if LT(off, (unbox_int happyMinOffset)) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
              new_state = indexShortOffAddr happyTable off_i
 #else
              _ = nt :: FAST_INT
@@ -262,7 +262,7 @@ happyGoto nt j tk st =
    DEBUG_TRACE(", goto state " ++ show IBOX(new_state) ++ "\n")
    happyDoAction j tk new_state
    where off = indexShortOffAddr happyGotoOffsets st
-         off_i = PLUS(off,nt)
+         off_i = if LT(off, (unbox_int happyMinOffset)) then PLUS(off, PLUS(nt, ILIT(65536))) else PLUS(off, nt)
          new_state = indexShortOffAddr happyTable off_i
 #else
 happyGoto action j tk st = action j j tk (HappyState action)


### PR DESCRIPTION
### This is an updated version of https://github.com/simonmar/happy/pull/98.

This fixes https://github.com/simonmar/happy/issues/93.

* Added new variable `happyMinOffset` that is present only when arrays are enabled.
This variable keeps track of the lowest offset value we should ever find in the
values of `happyActOffsets` and `happyGotoOffsets`. That way, if we ever find a
value that is smaller, we know it accidentally wrapped around (and we can correct
for the wraparound).

* Added a check so that if Happy is run with `--ghc` and the offset tables are
actually too large, Happy will fail with an error message instead of generating
bogus code (as it currently does).

Since the negative numbers in offset tables are generally quite small, this
effectively doubles the size of offsets supported.