### PR TITLE
Issue 94

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -120,6 +120,7 @@ extra-source-files:
 	tests/precedence002.y
 	tests/test_rules.y
         tests/issue91.y
+        tests/issue94.y
         tests/issue95.y
         tests/monaderror-explist.y
         tests/typeclass_monad001.y

--- a/src/Grammar.lhs
+++ b/src/Grammar.lhs
@@ -32,12 +32,6 @@ Here is our mid-section datatype
 
 > import Control.Monad.Writer
 
-#ifdef DEBUG
-
-> import System.IOExts
-
-#endif
-
 > type Name = Int
 
 > type Production = (Name,[Name],(String,[Int]),Priority)

--- a/src/LALR.lhs
+++ b/src/LALR.lhs
@@ -35,9 +35,24 @@ Generation of LALR parsing tables.
 This means rule $a$, with dot at $b$ (all starting at 0)
 
 > data Lr0Item = Lr0 {-#UNPACK#-}!Int {-#UNPACK#-}!Int                  -- (rule, dot)
->       deriving (Eq,Ord)
+>       deriving (Eq,Ord
+
+#ifdef DEBUG
+
+>       ,Show
+
+#endif
+
+>       )
 
 > data Lr1Item = Lr1 {-#UNPACK#-}!Int {-#UNPACK#-}!Int NameSet  -- (rule, dot, lookahead)
+
+#ifdef DEBUG
+
+>       deriving (Show)
+
+#endif
+
 > type RuleList = [Lr0Item]
 
 -----------------------------------------------------------------------------

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -107,14 +107,14 @@ Produce the complete output file.
 >                             . str "#endif" . nl
 >                       | otherwise = id
 >
->    n_types = length (filter isNothing (elems nt_types))
+>    n_missing_types = length (filter isNothing (elems nt_types))
 >    happyAbsSyn = str "(HappyAbsSyn " . str wild_tyvars . str ")"
->      where wild_tyvars = unwords (replicate n_types "_")
+>      where wild_tyvars = unwords (replicate n_missing_types "_")
 >
 >    -- This decides how to include (if at all) a type signature
 >    -- See <https://github.com/simonmar/happy/issues/94>
 >    filterTypeSig :: (String -> String) -> String -> String
->    filterTypeSig content | n_types == 0 = content
+>    filterTypeSig content | n_missing_types == 0 = content
 >                          | otherwise = ifGeGhc710 content
 >
 >    top_opts =

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -2,9 +2,6 @@
 
 #ifdef HAPPY_GHC
 #undef __GLASGOW_HASKELL__
-#define HAPPY_IF_GHC_GT_500 #if __GLASGOW_HASKELL__ > 500
-#define HAPPY_IF_GHC_GE_503 #if __GLASGOW_HASKELL__ >= 503
-#define HAPPY_ELIF_GHC_500 #elif __GLASGOW_HASKELL__ == 500
 #define HAPPY_IF_GHC_GT_706 #if __GLASGOW_HASKELL__ > 706
 #define HAPPY_ELSE #else
 #define HAPPY_ENDIF #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ endif
 
 TESTS = Test.ly TestMulti.ly TestPrecedence.ly bug001.ly \
 	monad001.y monad002.ly precedence001.ly precedence002.y \
-	bogus-token.y bug002.y Partial.ly issue91.y issue95.y \
+	bogus-token.y bug002.y Partial.ly issue91.y issue94.y issue95.y \
 	AttrGrammar001.y AttrGrammar002.y \
 	test_rules.y monaderror.y monaderror-explist.y \
 	typeclass_monad001.y typeclass_monad002.ly typeclass_monad_lexer.y

--- a/tests/issue94.y
+++ b/tests/issue94.y
@@ -1,0 +1,33 @@
+-- See <https://github.com/simonmar/happy/issues/94> for more information
+%name parse prod
+
+%tokentype { Token }
+
+%monad { P } { bindP } { returnP }
+%error { error "parse error" }
+%lexer { lexer } { EOF }
+
+%token
+  IDENT  { Identifier $$ }
+
+%%
+
+prod
+  : IDENT { () }
+
+{
+data Token = EOF | Identifier String
+
+type P a = String -> (a, String)
+
+bindP :: P a -> (a -> P b) -> P b
+bindP p f s = let (x,s') = p s in f x s'
+
+returnP :: a -> P a
+returnP = (,)
+
+lexer :: (Token -> P a) -> P a
+lexer cont s = cont (case s of { "" -> EOF; _ -> Identifier s }) ""
+
+main = return ()
+}


### PR DESCRIPTION
Implements both points outlined in comment <https://github.com/simonmar/happy/issues/94#issuecomment-329585023>. Also added a new test case which didn't use to pass, but does now.

This fixes #94. Someone should probably still update the user guide to summarize what <https://github.com/simonmar/happy/pull/49> added and the limitations that this PR imposes. Briefly, these are: if you want to have use type class constraints on the parsing monad without turning on `-XNoMonomorphismRestriction`

  * You must have a version of GHC >= 7.10.3
  * Otherwise, you must add type signatures to all of your productions