### PR TITLE
Semigroup-Monoid-Proposal

### DIFF
--- a/src/PrettyGrammar.hs
+++ b/src/PrettyGrammar.hs
@@ -1,5 +1,6 @@
 module PrettyGrammar where
 
+import Prelude hiding ((<>))
 import AbsSyn
 
 render :: Doc -> String


### PR DESCRIPTION
We now export `<>` from Prelude, which conflicts with the pretty printer.

This came up when trying to compile HEAD with HEAD using hadrian.