### PR TITLE
Add Paths_happy to other-modules

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -154,6 +154,7 @@ executable happy
   extensions: CPP, MagicHash, FlexibleContexts
   ghc-options: -Wall
   other-modules:
+        Paths_happy
         AbsSyn
         First
         GenUtils


### PR DESCRIPTION
This silences the missing-home-module warning.