### PR TITLE
Bumped upper version bound for Cabal library

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -129,7 +129,7 @@ extra-source-files:
         tests/typeclass_monad_lexer.y
 
 custom-setup
-  setup-depends: Cabal <2.1,
+  setup-depends: Cabal <2.2,
                  base <5,
                  directory <1.4,
                  filepath <1.5


### PR DESCRIPTION
Cabal 2.1.0.0. was shipped with GHC 8.4.1-alpha1 (announced [here](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html)). This PR allows to use this version of Cabal.