### PR TITLE
Fixed warning: Main module 'Main' listed in 'other-modules'

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -161,7 +161,6 @@ executable happy
         Info
         LALR
         Lexer
-        Main
         ParseMonad
         Parser
         ProduceCode


### PR DESCRIPTION
`cabal install` generates the following warning:

```
Warning: Enabling workaround for Main module 'Main' listed in 'other-modules'
illegally!
```

This PR fix this warning.

Tested with:

```
$ ghc -V
The Glorious Glasgow Haskell Compilation System, version 8.2.2

$ cabal --version
cabal-install version 2.0.0.1
compiled using version 2.0.1.0 of the Cabal library
```


