### PR TITLE
Relax upper bound on setup:Cabal to allow GHC 8.4.1's Cabal

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -129,7 +129,7 @@ extra-source-files:
         tests/typeclass_monad_lexer.y
 
 custom-setup
-  setup-depends: Cabal <2.2,
+  setup-depends: Cabal <2.4,
                  base >=4.6 && <5,
                  directory <1.4,
                  filepath <1.5


### PR DESCRIPTION
This was already performed on Hackage via revision to unblock GHC 8.4.1 install-plans:

http://hackage.haskell.org/package/happy-1.19.9/revisions/