### PR TITLE
Windows CI using stack + appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,12 @@ HappyTemplate-arrays-ghc
 HappyTemplate-arrays-ghc-debug
 HappyTemplate-coerce
 HappyTemplate-ghc
+
 .*.swp
 .*.swo
+
+#stack
+.stack-work
+
+# OSX
+.DS_Store

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+# Based on:
+#   https://github.com/commercialhaskell/stack/blob/master/appveyor.yml
+
+
+# Disabled cache in hope of improving reliability of AppVeyor builds
+#cache:
+#- "c:\\sr" # stack root, short paths == fewer problems
+
+build: off
+
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+  matrix:
+    - RESOLVER: "lts-11.9"           # ghc 8.2.2
+    - RESOLVER: "nightly-2018-06-07" # ghc 8.4.3
+    - RESOLVER: "nightly"
+
+matrix:
+  allow_failures:
+      - RESOLVER: nightly
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure https://get.haskellstack.org/stable/windows-i386.zip
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+
+test_script:
+- stack --resolver %RESOLVER% setup > nul
+- echo "" | stack --resolver %RESOLVER% --no-terminal test --jobs 1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,16 @@
+# http://docs.haskellstack.org/en/stable/yaml_configuration/
+
+# resolver by ghc version:
+#
+#   8.4.3:  nightly-2018-06-07
+#   8.2.2:  lts-11.9
+resolver: lts-11.9
+
+packages:
+- '.'
+
+extra-deps: []
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
Related to #124 :

That's a start, I used stack because it's what I use to develop. 

The current output is:

```shell
echo "" | stack --resolver nightly-2018-06-07 --no-terminal test --jobs 1
Updating package index Hackage (mirrored at https://s3.amazonaws.com/hackage.fpcomplete.com/) ...
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading root
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading timestamp
Downloading snapshot
Downloading mirrors
Cannot update index (no local copy)
Downloading index
Updated package index downloaded
Update complete
Populating index cache ...
Populated index cache.
Warning: Cabal file warning in C:\stack\happy.cabal@ 24:2: Tabs used as indentation at 24:2, 25:2,
         26:2, 27:2, 28:2, 29:2, 30:2, 31:2, 32:2, 33:2, 34:2, 35:2, 36:2, 37:2, 38:2, 39:2, 40:2,
         41:2, 42:2, 43:2, 44:2, 45:2, 46:2, 47:2, 48:2, 49:2, 50:2, 51:2, 52:2, 53:2, 54:2, 55:2,
         56:2, 57:2, 58:2, 59:2, 60:2, 61:2, 62:2, 63:2, 64:2, 65:2, 66:2, 67:2, 68:2, 69:2, 70:2,
         71:2, 72:2, 73:2, 74:2, 75:2, 76:2, 77:2, 78:2, 79:2, 80:2, 81:2, 82:2, 83:2, 84:2, 85:2,
         86:2, 87:2, 88:2, 89:2, 90:2, 91:2, 92:2, 93:2, 94:2, 95:2, 96:2, 97:2, 98:2, 99:2, 100:2,
         101:2, 102:2, 103:2, 104:2, 105:2, 106:2, 107:2, 108:2, 109:2, 110:2, 111:2, 112:2, 113:2,
         114:2, 115:2, 116:2, 117:2, 118:2, 119:2, 120:2, 121:2
Warning: There were multiple candidates for the Cabal entry " Parser 
         * C:\stack\src\Parser.ly 
         picking: C:\stack\src\Parser.hs
Warning: There were multiple candidates for the Cabal entry " AttrGrammarParser 
         * C:\stack\src\AttrGrammarParser.ly 
         picking: C:\stack\src\AttrGrammarParser.hs
[1 of 2] Compiling Main             ( C:\sr\setup-exe-src\setup-Z6RU0evB.hs, C:\sr\setup-exe-src\setup-Z6RU0evB.o )
[2 of 2] Compiling StackSetupShim   ( C:\sr\setup-exe-src\setup-shim-Z6RU0evB.hs, C:\sr\setup-exe-src\setup-shim-Z6RU0evB.o )
Linking C:\sr\setup-exe-cache\i386-windows\tmp-Cabal-simple_Z6RU0evB_2.2.0.1_ghc-8.4.3.exe ...
Building all executables for `happy' once. After a successful build of all of them, only specified executables will be rebuilt.
happy-1.19.9: configure (exe + test)
[1 of 2] Compiling Main             ( C:\stack\Setup.lhs, C:\stack\.stack-work\dist\ba067387\setup\Main.o )
C:\stack\Setup.lhs:48:22: warning: [-Wdeprecations]
    In the use of `rawSystemProgramConf'
    (imported from Distribution.Simple.Program):
    Deprecated: "use runDbProgram instead. This symbol will be removed in Cabal-3.0 (est. Oct 2018)."
   |
48 |   let runProgram p = rawSystemProgramConf (fromFlagOrDefault normal (buildVerbosity flags))
   |                      ^^^^^^^^^^^^^^^^^^^^
[2 of 2] Compiling StackSetupShim   ( C:\sr\setup-exe-src\setup-shim-Z6RU0evB.hs, C:\stack\.stack-work\dist\ba067387\setup\StackSetupShim.o )
Linking C:\stack\.stack-work\dist\ba067387\setup\setup.exe ...
Warning: happy.cabal:24:2: Tabs used as indentation at 24:2, 25:2, 26:2, 27:2,
28:2, 29:2, 30:2, 31:2, 32:2, 33:2, 34:2, 35:2, 36:2, 37:2, 38:2, 39:2, 40:2,
41:2, 42:2, 43:2, 44:2, 45:2, 46:2, 47:2, 48:2, 49:2, 50:2, 51:2, 52:2, 53:2,
54:2, 55:2, 56:2, 57:2, 58:2, 59:2, 60:2, 61:2, 62:2, 63:2, 64:2, 65:2, 66:2,
67:2, 68:2, 69:2, 70:2, 71:2, 72:2, 73:2, 74:2, 75:2, 76:2, 77:2, 78:2, 79:2,
80:2, 81:2, 82:2, 83:2, 84:2, 85:2, 86:2, 87:2, 88:2, 89:2, 90:2, 91:2, 92:2,
93:2, 94:2, 95:2, 96:2, 97:2, 98:2, 99:2, 100:2, 101:2, 102:2, 103:2, 104:2,
105:2, 106:2, 107:2, 108:2, 109:2, 110:2, 111:2, 112:2, 113:2, 114:2, 115:2,
116:2, 117:2, 118:2, 119:2, 120:2, 121:2
Configuring happy-1.19.9...
happy-1.19.9: build (exe + test)
Preprocessing executable 'happy' for happy-1.19.9..
setup.exe: The program 'happy' is required but it could not be found
--  While building custom Setup.hs for package happy-1.19.9 using:
      C:\stack\.stack-work\dist\ba067387\setup\setup --builddir=.stack-work\dist\ba067387 build exe:happy test:tests --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
Command exited with code 1
```

I wonder where these warnings come from:  
```
Warning: There were multiple candidates for the Cabal entry " Parser 
         * C:\stack\src\Parser.ly 
         picking: C:\stack\src\Parser.hs
Warning: There were multiple candidates for the Cabal entry " AttrGrammarParser 
         * C:\stack\src\AttrGrammarParser.ly 
         picking: C:\stack\src\AttrGrammarParser.hs
```

full output : https://ci.appveyor.com/project/OlivierSohn/happy/build/1.0.2

