### PR TITLE
bump for GHC 8.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - GHCVER=8.0.2
  - GHCVER=8.2.2
  - GHCVER=8.4.3
+ - GHCVER=8.6.1
 
 before_install:
  - sudo add-apt-repository -y ppa:hvr/ghc

--- a/Setup.lhs
+++ b/Setup.lhs
@@ -45,9 +45,9 @@ symbols cs = case lex cs of
               _ -> []
 
 myPostBuild _ flags _ lbi = do
-  let runProgram p = rawSystemProgramConf (fromFlagOrDefault normal (buildVerbosity flags))
-                                          p
-                                          (withPrograms lbi)
+  let runProgram p = runDbProgram (fromFlagOrDefault normal (buildVerbosity flags))
+                                  p
+                                  (withPrograms lbi)
       cpp_template src dst opts = do
         let tmp = dst ++ ".tmp"
         runProgram ghcProgram (["-o", tmp, "-E", "-cpp", "templates" </> src] ++ opts)

--- a/happy.cabal
+++ b/happy.cabal
@@ -129,7 +129,7 @@ extra-source-files:
         tests/typeclass_monad_lexer.y
 
 custom-setup
-  setup-depends: Cabal <2.4,
+  setup-depends: Cabal <2.5,
                  base >=4.6 && <5,
                  directory <1.4,
                  filepath <1.5


### PR DESCRIPTION
This bumps Cabal bounds to allow building with GHC 8.6.1 and removes a deprecated function from `Setup.lhs`. 