### PR TITLE
Apply failP changes to .hs files used for bootstrap

### DIFF
--- a/src/AttrGrammarParser.hs
+++ b/src/AttrGrammarParser.hs
@@ -339,7 +339,7 @@ happySeq = happyDontSeq
 
 
 happyError :: P a
-happyError = fail ("Parse error\n")
+happyError = failP ("Parse error\n")
 {-# LINE 1 "templates/GenericTemplate.hs" #-}
 {-# LINE 1 "templates/GenericTemplate.hs" #-}
 {-# LINE 1 "<built-in>" #-}

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -736,7 +736,7 @@ happySeq = happyDontSeq
 
 
 happyError :: P a
-happyError = lineP >>= \l -> fail (show l ++ ": Parse error\n")
+happyError = lineP >>= \l -> failP (show l ++ ": Parse error\n")
 {-# LINE 1 "templates/GenericTemplate.hs" #-}
 {-# LINE 1 "templates/GenericTemplate.hs" #-}
 {-# LINE 1 "<built-in>" #-}


### PR DESCRIPTION
I believe this fixes https://github.com/simonmar/happy/issues/139

As of now, the latest `happy` tarball release will not build with GHC 8.8.1