### PR TITLE
Setup.hs: Compatibility with Cabal-3

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -44,7 +44,7 @@ symbols cs = case lex cs of
               _ -> []
 
 myPostBuild _ flags _ lbi = do
-  let runProgram p = rawSystemProgramConf (fromFlagOrDefault normal (buildVerbosity flags))
+  let runProgram p = runDbProgram (fromFlagOrDefault normal (buildVerbosity flags))
                                           p
                                           (withPrograms lbi)
       cpp_template src dst opts = do

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,5 @@
 #!/usr/bin/runhaskell
 
-\begin{code}
 {-# OPTIONS -fwarn-unused-imports #-}
 module Main where
 
@@ -102,4 +101,3 @@ glr_templates = [
   ("GLR_Lib-ghc-debug"  , ["-DHAPPY_GHC", "-DHAPPY_DEBUG"])
  ]
 
-\end{code}

--- a/happy.cabal
+++ b/happy.cabal
@@ -130,7 +130,7 @@ extra-source-files:
         tests/rank2.y
 
 custom-setup
-  setup-depends: Cabal <2.6,
+  setup-depends: Cabal <3.1,
                  base >=4.6 && <5,
                  directory <1.4,
                  filepath <1.5


### PR DESCRIPTION
https://github.com/haskell/cabal/pull/3693 deprecated `rawSystemProgramConf` in favor of `runDbProgram`.
