### PR TITLE
Replace type synonyms with proper types, add docs

### DIFF
--- a/src/AbsSyn.lhs
+++ b/src/AbsSyn.lhs
@@ -12,19 +12,34 @@ Here is the abstract syntax of the language we parse.
 >       getImportedIdentity, getMonad, getError,
 >       getPrios, getPrioNames, getExpect, getErrorHandlerType,
 >       getAttributes, getAttributetype,
->       Rule,Prod,Term(..)
+>       Rule(..), Prod(..), Term(..)
 >  ) where
 
 > data AbsSyn
 >     = AbsSyn
->         (Maybe String)                                        -- header
->         [Directive String]                                    -- directives
->         [Rule]        -- productions
->         (Maybe String)                                        -- footer
+>         (Maybe String)       -- header
+>         [Directive String]   -- directives
+>         [Rule]               -- productions
+>         (Maybe String)       -- footer
 
-> type Rule     = (String,[String],[Prod],Maybe String)
-> type Prod     = ([Term],String,Int,Maybe String)
-> data Term     = App String [Term]
+> data Rule
+>     = Rule
+>         String               -- name of the rule
+>         [String]             -- parameters (see parametrized productions)
+>         [Prod]               -- productions
+>         (Maybe String)       -- type of the rule
+
+> data Prod
+>     = Prod
+>         [Term]               -- terms that make up the rule
+>         String               -- code body that runs when the rule reduces
+>         Int                  -- line number
+>         (Maybe String)       -- inline precedence annotation for the rule
+
+> data Term
+>     = App
+>         String               -- name of the term
+>         [Term]               -- parameter arguments (usually this is empty)
 
 
 

--- a/src/First.lhs
+++ b/src/First.lhs
@@ -34,7 +34,7 @@ Implementation of FIRST
 >       env = mkClosure (==) (getNext fst_term prodNo prodsOfName)
 >               [ (name,Set.empty) | name <- nts ]
 
-> getNext :: Name -> (a -> (b, [Name], c, d)) -> (Name -> [a])
+> getNext :: Name -> (a -> Production) -> (Name -> [a])
 >         -> [(Name, IntSet)] -> [(Name, NameSet)]
 > getNext fst_term prodNo prodsOfName env =
 >               [ (nm, next nm) | (nm,_) <- env ]
@@ -45,10 +45,7 @@ Implementation of FIRST
 >       next :: Name -> NameSet
 >       next t | t >= fst_term = Set.singleton t
 >       next n = Set.unions
->                       [ joinSymSets fn (snd4 (prodNo rl)) |
->                               rl <- prodsOfName n ]
+>                       [ joinSymSets fn lhs
+>                       | rl <- prodsOfName n
+>                       , let Production _ lhs _ _ = prodNo rl ]
 
-My little hack
-
-> snd4 :: (a, b, c, d) -> b
-> snd4 (_,b,_,_) = b

--- a/src/Info.lhs
+++ b/src/Info.lhs
@@ -96,7 +96,7 @@ Produce a file of parser information, useful for debugging the parser.
 >       . interleave "\n" (zipWith showProduction prods [ 0 :: Int .. ])
 >       . str "\n"
 
->   showProduction (nt, toks, _sem, _prec) i
+>   showProduction (Production nt toks _sem _prec) i
 >       = ljuststr 50 (
 >         str "\t"
 >       . showName nt
@@ -128,7 +128,7 @@ Produce a file of parser information, useful for debugging the parser.
 >               . interleave " " (map showName afterDot))
 >       . str "   (rule " . shows rule . str ")"
 >       where
->               (nt, toks, _sem, _prec) = lookupProd rule
+>               Production nt toks _sem _prec = lookupProd rule
 >               (beforeDot, afterDot) = splitAt dot toks
 
 >   showAction (_, LR'Fail)

--- a/src/LALR.lhs
+++ b/src/LALR.lhs
@@ -123,7 +123,7 @@ Generating the closure of a set of LR(1) items
 >                           in
 >                           [ (Lr1 rule' 0 terms) | rule' <- lookupProdsOfName g b ]
 >                       _ -> []
->                   where (_name,lhs,_,_) = lookupProdNo g rule
+>                   where Production _name lhs _ _ = lookupProdNo g rule
 
 Subtract the first set of items from the second.
 
@@ -495,8 +495,8 @@ Generate the action table
 >                  -> let (_,_,_,partial) = starts' !! rule in
 >                     [ (startLookahead g partial, LR'Accept{-'-}) ]
 >                  | otherwise
->                  -> case lookupProdNo g rule of
->                          (_,_,_,p) -> NameSet.toAscList la `zip` repeat (LR'Reduce rule p)
+>                  -> let Production _ _ _ p = lookupProdNo g rule in
+>                     NameSet.toAscList la `zip` repeat (LR'Reduce rule p)
 >               _ -> []
 
 >       possActions goto coll = do item <- closure1 g first coll
@@ -609,4 +609,4 @@ Count the conflicts
 
 > findRule :: Grammar -> Int -> Int -> Maybe Name
 > findRule g rule dot = listToMaybe (drop dot lhs)
->     where (_,lhs,_,_) = lookupProdNo g rule
+>     where Production _ lhs _ _ = lookupProdNo g rule

--- a/src/Parser.ly
+++ b/src/Parser.ly
@@ -59,9 +59,9 @@ The parser.
 >       | rule          { [$1] }
 
 > rule :: { Rule }
->       : id params "::" code ":" prods         { ($1,$2,$6,Just $4) }
->       | id params "::" code id ":" prods      { ($1,$2,$7,Just $4) }
->       | id params ":" prods                   { ($1,$2,$4,Nothing) }
+>       : id params "::" code ":" prods         { Rule $1 $2 $6 (Just $4) }
+>       | id params "::" code id ":" prods      { Rule $1 $2 $7 (Just $4) }
+>       | id params ":" prods                   { Rule $1 $2 $4 Nothing }
 
 > params :: { [String] }
 >       : "(" comma_ids ")"             { reverse $2 }
@@ -76,8 +76,8 @@ The parser.
 >       | prod                          { [$1] }
 
 > prod :: { Prod }
->       : terms prec code ";"           {% lineP >>= \l -> return ($1,$3,l,$2) }
->       | terms prec code               {% lineP >>= \l -> return ($1,$3,l,$2) }
+>       : terms prec code ";"           {% lineP >>= \l -> return (Prod $1 $3 l $2) }
+>       | terms prec code               {% lineP >>= \l -> return (Prod $1 $3 l $2) }
 
 > term :: { Term }
 >       : id                             { App $1 [] }

--- a/src/PrettyGrammar.hs
+++ b/src/PrettyGrammar.hs
@@ -23,13 +23,13 @@ ppDirective dir =
   prec x xs = text x <+> hsep (map text xs)
 
 ppRule :: Rule -> Doc
-ppRule (name,_,prods,_) = text name
-                       $$ vcat (zipWith (<+>) starts (map ppProd prods))
+ppRule (Rule name _ prods _) = text name
+                            $$ vcat (zipWith (<+>) starts (map ppProd prods))
   where
   starts = text "  :" : repeat (text "  |")
 
 ppProd :: Prod -> Doc
-ppProd (ts,_,_,p) = psDoc <+> precDoc
+ppProd (Prod ts _ _ p) = psDoc <+> precDoc
   where
   psDoc   = if null ts then text "{- empty -}" else hsep (map ppTerm ts)
   precDoc = maybe empty (\x -> text "%prec" <+> text x) p

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -323,7 +323,7 @@ happyMonadReduce to get polymorphic recursion.  Sigh.
 >       interleave "\n\n"
 >          (zipWith produceReduction (drop n_starts prods) [ n_starts .. ])
 
->    produceReduction (nt, toks, (code,vars_used), _) i
+>    produceReduction (Production nt toks (code,vars_used) _) i
 
 >     | is_monad_prod && (use_monad || imported_identity')
 >       = mkReductionHdr (showInt lt) monad_reduce

--- a/src/ProduceGLRCode.lhs
+++ b/src/ProduceGLRCode.lhs
@@ -348,10 +348,11 @@ It also shares identical reduction values as CAFs
 >     mkReds rs = "[" ++ tail (concat [ "," ++ mkRed r | LR'Reduce r _ <- rs ]) ++ "]"
 
 >   mkRed r = "red_" ++ show r
->   mkReductions = [ mkRedDefn p | p@(_,(n,_,_,_)) <- zip [0..] $ productions g
->                                , n `notElem` start_productions g ]
+>   mkReductions = [ mkRedDefn p
+>                  | p@(_, Production n _ _ _) <- zip [0..] $ productions g
+>                  , n `notElem` start_productions g ]
 
->   mkRedDefn (r, (lhs_id, rhs_ids, (_code,_dollar_vars), _))
+>   mkRedDefn (r, Production lhs_id rhs_ids (_code,_dollar_vars) _)
 >    = mkRed r ++ " = ("++ lhs ++ "," ++ show arity ++ " :: Int," ++ sem ++")"
 >      where
 >         lhs = toGSym gsMap $ lhs_id
@@ -475,7 +476,7 @@ Creating a type for storing semantic rules
 >          | i <- user_non_terminals g
 >          , let i_ty = typeOf i
 >          , j <- lookupProdsOfName g i  -- all prod numbers
->          , let (_,ts,(raw_code,dollar_vars),_) = lookupProdNo g j
+>          , let Production _ ts (raw_code,dollar_vars) _ = lookupProdNo g j
 >          , let var_mask = map (\x -> x - 1) vars_used
 >                           where vars_used = sort $ nub dollar_vars
 >          , let args = [ typeOf $ ts !! v | v <- var_mask ]
@@ -520,7 +521,7 @@ Creating a type for storing semantic rules
 >          | i <- user_non_terminals g
 >          , let i_ty = typeOf i
 >          , j <- lookupProdsOfName g i  -- all prod numbers
->          , let (_,ts,(code,dollar_vars),_) = lookupProdNo g j
+>          , let Production _ ts (code,dollar_vars) _ = lookupProdNo g j
 >          , let var_mask = map (\x -> x - 1) vars_used
 >                           where vars_used = sort $ nub dollar_vars
 >          , let ts_pats = [ (k+1,c) | k <- var_mask


### PR DESCRIPTION
This commit changes no new functionality, but hopefully it makes the
code more readable and less prone to accidental type confusion. All
refactoring is very mechanical:

  * replace type synonyms of large tuples with proper types
  * add conservative comments to data types and functions
  * add a handful of type signatures