### PR TITLE
qualify Prelude functions in templates

### DIFF
--- a/src/AbsSyn.lhs
+++ b/src/AbsSyn.lhs
@@ -114,7 +114,7 @@ generate some error messages.
 > getMonad ds
 >       = case [ (True,a,b,c,d) | (TokenMonad a b c d) <- ds ] of
 >               [t] -> t
->               []  -> (False,"()","HappyIdentity",">>=","return")
+>               []  -> (False,"()","HappyIdentity","Prelude.>>=","Prelude.return")
 >               _   -> error "multiple monad directives"
 
 > getTokenSpec :: [Directive t] -> [(t, String)]

--- a/src/Grammar.lhs
+++ b/src/Grammar.lhs
@@ -512,7 +512,7 @@ So is this.
 >                     , attrUpdates
 >                     ]
 >
->        formattedConditions = concat $ intersperse "++" $ localConditions : (map (\i -> "happyConditions_"++(show i)) prods)
+>        formattedConditions = concat $ intersperse " Prelude.++ " $ localConditions : (map (\i -> "happyConditions_"++(show i)) prods)
 >        localConditions = "["++(concat $ intersperse ", " $ map formatCondition conditions)++"]"
 >        formatCondition (Conditional toks) = formatTokens toks
 >        formatCondition _ = error "formatCondition: Not a condition"

--- a/src/Parser.ly
+++ b/src/Parser.ly
@@ -112,8 +112,8 @@ The parser.
 >       | spec_partial id optStart      { TokenName $2 $3 True  }
 >       | spec_imported_identity        { TokenImportedIdentity }
 >       | spec_lexer code code          { TokenLexer $2 $3 }
->       | spec_monad code               { TokenMonad "()" $2 ">>=" "return" }
->       | spec_monad code code          { TokenMonad $2 $3 ">>=" "return" }
+>       | spec_monad code               { TokenMonad "()" $2 "Prelude.>>=" "Prelude.return" }
+>       | spec_monad code code          { TokenMonad $2 $3 "Prelude.>>=" "Prelude.return" }
 >       | spec_monad code code code     { TokenMonad "()" $2 $3 $4 }
 >       | spec_monad code code code code        { TokenMonad $2 $3 $4 $5 }
 >       | spec_nonassoc ids             { TokenNonassoc $2 }

--- a/src/ProduceCode.lhs
+++ b/src/ProduceCode.lhs
@@ -93,7 +93,7 @@ Produce the complete output file.
 >    partTySigs_opts = ifGeGhc710 (str "{-# OPTIONS_GHC -XPartialTypeSignatures #-}" . nl)
 >
 >    intMaybeHash | ghc       = str "Happy_GHC_Exts.Int#"
->                 | otherwise = str "Int"
+>                 | otherwise = str "Prelude.Int"
 >
 >    -- Parsing monad and its constraints
 >    pty = str monad_tycon
@@ -216,7 +216,7 @@ example where this matters.
 >     | otherwise
 >       = str "data HappyAbsSyn " . str_tyvars
 >       . str "\n\t= HappyTerminal " . token
->       . str "\n\t| HappyErrorToken Int\n"
+>       . str "\n\t| HappyErrorToken Prelude.Int\n"
 >       . interleave "\n"
 >         [ str "\t| " . makeAbsSynCon n . strspace . typeParam n ty
 >         | (n, ty) <- assocs nt_types,
@@ -583,8 +583,8 @@ machinery to discard states in the parser...
 >    produceActionTable TargetArrayBased
 >       = produceActionArray
 >       . produceReduceArray
->       . str "happy_n_terms = " . shows n_terminals . str " :: Int\n"
->       . str "happy_n_nonterms = " . shows n_nonterminals . str " :: Int\n\n"
+>       . str "happy_n_terms = " . shows n_terminals . str " :: Prelude.Int\n"
+>       . str "happy_n_nonterms = " . shows n_nonterminals . str " :: Prelude.Int\n\n"
 >
 >    produceExpListPerState
 >       = produceExpListArray
@@ -592,15 +592,15 @@ machinery to discard states in the parser...
 >       . str "happyExpListPerState st =\n"
 >       . str "    token_strs_expected\n"
 >       . str "  where token_strs = " . str (show $ elems token_names') . str "\n"
->       . str "        bit_start = st * " . str (show nr_tokens) . str "\n"
->       . str "        bit_end = (st + 1) * " . str (show nr_tokens) . str "\n"
+>       . str "        bit_start = st Prelude.* " . str (show nr_tokens) . str "\n"
+>       . str "        bit_end = (st Prelude.+ 1) Prelude.* " . str (show nr_tokens) . str "\n"
 >       . str "        read_bit = readArrayBit happyExpList\n"
->       . str "        bits = map read_bit [bit_start..bit_end - 1]\n"
->       . str "        bits_indexed = zip bits [0.."
+>       . str "        bits = Prelude.map read_bit [bit_start..bit_end Prelude.- 1]\n"
+>       . str "        bits_indexed = Prelude.zip bits [0.."
 >                                        . str (show (nr_tokens - 1)) . str "]\n"
->       . str "        token_strs_expected = concatMap f bits_indexed\n"
->       . str "        f (False, _) = []\n"
->       . str "        f (True, nr) = [token_strs !! nr]\n"
+>       . str "        token_strs_expected = Prelude.concatMap f bits_indexed\n"
+>       . str "        f (Prelude.False, _) = []\n"
+>       . str "        f (Prelude.True, nr) = [token_strs Prelude.!! nr]\n"
 >       . str "\n"
 >       where (first_token, last_token) = bounds token_names'
 >             nr_tokens = last_token - first_token + 1
@@ -693,34 +693,34 @@ action array indexed by (terminal * last_state) + state
 >           . str "\"#\n\n" --"
 
 >       | otherwise
->           = str "happyActOffsets :: Happy_Data_Array.Array Int Int\n"
+>           = str "happyActOffsets :: Happy_Data_Array.Array Prelude.Int Prelude.Int\n"
 >           . str "happyActOffsets = Happy_Data_Array.listArray (0,"
 >               . shows n_states . str ") (["
 >           . interleave' "," (map shows act_offs)
 >           . str "\n\t])\n\n"
 >
->           . str "happyGotoOffsets :: Happy_Data_Array.Array Int Int\n"
+>           . str "happyGotoOffsets :: Happy_Data_Array.Array Prelude.Int Prelude.Int\n"
 >           . str "happyGotoOffsets = Happy_Data_Array.listArray (0,"
 >               . shows n_states . str ") (["
 >           . interleave' "," (map shows goto_offs)
 >           . str "\n\t])\n\n"
 >           
->           . str "happyAdjustOffset :: Int -> Int\n"
->           . str "happyAdjustOffset = id\n\n"
+>           . str "happyAdjustOffset :: Prelude.Int -> Prelude.Int\n"
+>           . str "happyAdjustOffset = Prelude.id\n\n"
 >
->           . str "happyDefActions :: Happy_Data_Array.Array Int Int\n"
+>           . str "happyDefActions :: Happy_Data_Array.Array Prelude.Int Prelude.Int\n"
 >           . str "happyDefActions = Happy_Data_Array.listArray (0,"
 >               . shows n_states . str ") (["
 >           . interleave' "," (map shows defaults)
 >           . str "\n\t])\n\n"
 >
->           . str "happyCheck :: Happy_Data_Array.Array Int Int\n"
+>           . str "happyCheck :: Happy_Data_Array.Array Prelude.Int Prelude.Int\n"
 >           . str "happyCheck = Happy_Data_Array.listArray (0,"
 >               . shows table_size . str ") (["
 >           . interleave' "," (map shows check)
 >           . str "\n\t])\n\n"
 >
->           . str "happyTable :: Happy_Data_Array.Array Int Int\n"
+>           . str "happyTable :: Happy_Data_Array.Array Prelude.Int Prelude.Int\n"
 >           . str "happyTable = Happy_Data_Array.listArray (0,"
 >               . shows table_size . str ") (["
 >           . interleave' "," (map shows table)
@@ -733,7 +733,7 @@ action array indexed by (terminal * last_state) + state
 >           . str (hexChars explist)
 >           . str "\"#\n\n" --"
 >       | otherwise
->           = str "happyExpList :: Happy_Data_Array.Array Int Int\n"
+>           = str "happyExpList :: Happy_Data_Array.Array Prelude.Int Prelude.Int\n"
 >           . str "happyExpList = Happy_Data_Array.listArray (0,"
 >               . shows table_size . str ") (["
 >           . interleave' "," (map shows explist)
@@ -806,12 +806,12 @@ outlaw them inside { }
 >            str "newtype HappyIdentity a = HappyIdentity a\n"
 >          . str "happyIdentity = HappyIdentity\n"
 >          . str "happyRunIdentity (HappyIdentity a) = a\n\n"
->          . str "instance Functor HappyIdentity where\n"
+>          . str "instance Prelude.Functor HappyIdentity where\n"
 >          . str "    fmap f (HappyIdentity a) = HappyIdentity (f a)\n\n"
 >          . str "instance Applicative HappyIdentity where\n"
 >          . str "    pure  = HappyIdentity\n"
 >          . str "    (<*>) = ap\n"
->          . str "instance Monad HappyIdentity where\n"
+>          . str "instance Prelude.Monad HappyIdentity where\n"
 >          . str "    return = pure\n"
 >          . str "    (HappyIdentity p) >>= q = q p\n\n"
 
@@ -855,11 +855,11 @@ MonadStuff:
 >                . str " a\n"
 >                . str "happyError' :: " . str monad_context . str " => (["
 >                . token
->                . str "], [String]) -> "
+>                . str "], [Prelude.String]) -> "
 >                . str monad_tycon
 >                . str " a\n"
 >                . str "happyError' = "
->                . str (if use_monad then "" else "HappyIdentity . ")
+>                . str (if use_monad then "" else "HappyIdentity Prelude.. ")
 >                . errorHandler . str "\n"
 >               _ ->
 >                let
@@ -887,7 +887,7 @@ MonadStuff:
 >                  reduceArrSig
 >                    | target == TargetArrayBased =
 >                      str "happyReduceArr :: " . pcont
->                      . str " => Happy_Data_Array.Array Int (" . intMaybeHash
+>                      . str " => Happy_Data_Array.Array Prelude.Int (" . intMaybeHash
 >                      . str " -> " . str token_type' . str " -> " . intMaybeHash
 >                      . str " -> Happy_IntList -> HappyStk " . happyAbsSyn
 >                      . str " -> " . pty . str " " . happyAbsSyn . str ")\n"
@@ -901,7 +901,7 @@ MonadStuff:
 >                . str "happyReturn1 :: " . pcont . str " => a -> " . pty . str " a\n"
 >                . str "happyReturn1 = happyReturn\n"
 >                . str "happyError' :: " . str monad_context . str " => ("
->                                        . token . str ", [String]) -> "
+>                                        . token . str ", [Prelude.String]) -> "
 >                . str monad_tycon
 >                . str " a\n"
 >                . str "happyError' tk = "
@@ -977,21 +977,21 @@ directive determins the API of the provided function.
 >         . str "do { "
 >         . str "f <- do_" . str name . str "; "
 >         . str "let { (conds,attrs) = f happyEmptyAttrs } in do { "
->         . str "sequence_ conds; "
->         . str "return (". str defaultAttr . str " attrs) }}"
+>         . str "Prelude.sequence_ conds; "
+>         . str "Prelude.return (". str defaultAttr . str " attrs) }}"
 >       monadAE name
 >         = str name . str " toks = "
 >         . str "do { "
 >         . str "f <- do_" . str name . str " toks; "
 >         . str "let { (conds,attrs) = f happyEmptyAttrs } in do { "
->         . str "sequence_ conds; "
->         . str "return (". str defaultAttr . str " attrs) }}"
+>         . str "Prelude.sequence_ conds; "
+>         . str "Prelude.return (". str defaultAttr . str " attrs) }}"
 >       regularAE name
 >         = str name . str " toks = "
 >         . str "let { "
 >         . str "f = do_" . str name . str " toks; "
 >         . str "(conds,attrs) = f happyEmptyAttrs; "
->         . str "x = foldr seq attrs conds; "
+>         . str "x = Prelude.foldr Prelude.seq attrs conds; "
 >         . str "} in (". str defaultAttr . str " x)"
 
 ----------------------------------------------------------------------------
@@ -1006,7 +1006,7 @@ directive determins the API of the provided function.
 >   where attributes'  = foldl1 (\x y -> x . str ", " . y) $ map formatAttribute attrs
 >         formatAttribute (ident,typ) = str ident . str " :: " . str typ
 >         attrsErrors = foldl1 (\x y -> x . str ", " . y) $ map attrError attrs
->         attrError (ident,_) = str ident . str " = error \"invalid reference to attribute '" . str ident . str "'\""
+>         attrError (ident,_) = str ident . str " = Prelude.error \"invalid reference to attribute '" . str ident . str "'\""
 >         attrHeader =
 >             case attributeType of
 >             [] -> str "HappyAttributes"

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -14,9 +14,9 @@
 #define FAST_INT Happy_GHC_Exts.Int#
 -- Do not remove this comment. Required to fix CPP parsing when using GCC and a clang-compiled alex.
 HAPPY_IF_GHC_GT_706
-HAPPY_DEFINE LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Bool)
-HAPPY_DEFINE GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Bool)
-HAPPY_DEFINE EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Bool)
+HAPPY_DEFINE LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Prelude.Bool)
+HAPPY_DEFINE GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Prelude.Bool)
+HAPPY_DEFINE EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Prelude.Bool)
 HAPPY_ELSE
 HAPPY_DEFINE LT(n,m) (n Happy_GHC_Exts.<# m)
 HAPPY_DEFINE GTE(n,m) (n Happy_GHC_Exts.>=# m)
@@ -30,14 +30,14 @@ HAPPY_ENDIF
 #else
 #define ILIT(n) (n)
 #define IBOX(n) (n)
-#define FAST_INT Int
-#define LT(n,m) (n < m)
-#define GTE(n,m) (n >= m)
-#define EQ(n,m) (n == m)
-#define PLUS(n,m) (n + m)
-#define MINUS(n,m) (n - m)
-#define TIMES(n,m) (n * m)
-#define NEGATE(n) (negate (n))
+#define FAST_INT Prelude.Int
+#define LT(n,m) (n Prelude.< m)
+#define GTE(n,m) (n Prelude.>= m)
+#define EQ(n,m) (n Prelude.== m)
+#define PLUS(n,m) (n Prelude.+ m)
+#define MINUS(n,m) (n Prelude.- m)
+#define TIMES(n,m) (n Prelude.* m)
+#define NEGATE(n) (Prelude.negate (n))
 #define IF_GHC(x)
 #endif
 
@@ -112,7 +112,7 @@ happyDoAction i tk st
                       ",\taction: ")
           case action of
                 ILIT(0)           -> DEBUG_TRACE("fail.\n")
-                                     happyFail (happyExpListPerState (IBOX(st) :: Int)) i tk st
+                                     happyFail (happyExpListPerState (IBOX(st) :: Prelude.Int)) i tk st
                 ILIT(-1)          -> DEBUG_TRACE("accept.\n")
                                      happyAccept i tk st
                 n | LT(n,(ILIT(0) :: FAST_INT)) -> DEBUG_TRACE("reduce (rule " ++ show rule
@@ -128,10 +128,10 @@ happyDoAction i tk st
          off_i  = PLUS(off, i)
          check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
                   then EQ(indexShortOffAddr happyCheck off_i, i)
-                  else False
+                  else Prelude.False
          action
           | check     = indexShortOffAddr happyTable off_i
-          | otherwise = indexShortOffAddr happyDefActions st
+          | Prelude.otherwise = indexShortOffAddr happyDefActions st
 
 #endif /* HAPPY_ARRAY */
 
@@ -152,11 +152,11 @@ happyLt x y = LT(x,y)
 
 #ifdef HAPPY_GHC
 readArrayBit arr bit =
-    Bits.testBit IBOX(indexShortOffAddr arr ((unbox_int bit) `Happy_GHC_Exts.iShiftRA#` 4#)) (bit `mod` 16)
+    Bits.testBit IBOX(indexShortOffAddr arr ((unbox_int bit) `Happy_GHC_Exts.iShiftRA#` 4#)) (bit `Prelude.mod` 16)
   where unbox_int (Happy_GHC_Exts.I# x) = x
 #else
 readArrayBit arr bit =
-    Bits.testBit IBOX(indexShortOffAddr arr (bit `div` 16)) (bit `mod` 16)
+    Bits.testBit IBOX(indexShortOffAddr arr (bit `Prelude.div` 16)) (bit `Prelude.mod` 16)
 #endif
 
 #ifdef HAPPY_GHC
@@ -296,7 +296,7 @@ happyFail explist i tk HAPPYSTATE(action) sts stk =
 -- Internal happy errors:
 
 notHappyAtAll :: a
-notHappyAtAll = error "Internal Happy error\n"
+notHappyAtAll = Prelude.error "Internal Happy error\n"
 
 -----------------------------------------------------------------------------
 -- Hack to get the typechecker to accept our action functions
@@ -314,7 +314,7 @@ happyTcHack x y = y
 --      happySeq = happyDontSeq
 
 happyDoSeq, happyDontSeq :: a -> b -> b
-happyDoSeq   a b = a `seq` b
+happyDoSeq   a b = a `Prelude.seq` b
 happyDontSeq a b = b
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
This is a less ambitious resolution to https://github.com/simonmar/happy/issues/131 than https://github.com/simonmar/happy/pull/135 was.

The compiler construction course in which the underlying issue arose last year is due to start again now. I see that making a more comprehensive fix, which would prevent problems like this from arising in `happy` again in the future, is stalled in discussion between @Kellador and @simonmar over in https://github.com/simonmar/happy/pull/135. CC'ing @owestphal, who would have to deal with students' problems arising from name clashes between Prelude functions and own functions in the practical part of the course.

The pull request here does the minimal thing. No interface changes (that is, no new cli options) to `happy`, no preprocessor magic, no changes to the test suite. Just adding `Prelude` to all places where it is necessary to prevent `happy` not working with grammar files that include
```haskell
import Prelude hiding (... something ...)
import qualified Prelude
```
(Where "all places" is defined as the list of locations that https://github.com/simonmar/happy/pull/135 found necessary to change. Since that over there compiles, I think there is a guarantee here that no relevant place was missed.)

I don't see any possibility of problems with this pull request concerning any current use of Happy, since it is a completely conservative change.

A more complete fix can still be attempted later, but I hope this here is acceptable.