### PR TITLE
Debug options in all build configurations

### DIFF
--- a/src/AbsSyn.lhs
+++ b/src/AbsSyn.lhs
@@ -45,13 +45,7 @@ Here is the abstract syntax of the language we parse.
 >     = PrecNone               -- no user-specified precedence
 >     | PrecShift              -- %shift
 >     | PrecId String          -- %prec ID
-
-
-#ifdef DEBUG
-
 >   deriving Show
-
-#endif
 
 %-----------------------------------------------------------------------------
 Parser Generator Directives.
@@ -78,13 +72,7 @@ generate some error messages.
 >       | TokenError    String                  -- %error
 >       | TokenAttributetype String             -- %attributetype
 >       | TokenAttribute String String          -- %attribute
-
-
-#ifdef DEBUG
-
 >   deriving Show
-
-#endif
 
 > getTokenType :: [Directive t] -> String
 > getTokenType ds

--- a/src/Grammar.lhs
+++ b/src/Grammar.lhs
@@ -44,12 +44,7 @@ This is only supported in the bootstrapped version
 
 > data Production
 >       = Production Name [Name] (String,[Int]) Priority
-
-#ifdef DEBUG
-
 >       deriving Show
-
-#endif
 
 > data Grammar
 >       = Grammar {
@@ -77,8 +72,6 @@ This is only supported in the bootstrapped version
 >               error_sig         :: ErrorHandlerType
 >       }
 
-#ifdef DEBUG
-
 > instance Show Grammar where
 >       showsPrec _ (Grammar
 >               { productions           = p
@@ -104,23 +97,11 @@ This is only supported in the bootstrapped version
 >        . showString "\neof = "           . shows eof
 >        . showString "\n"
 
-#endif
-
 > data Assoc = LeftAssoc | RightAssoc | None
-
-#ifdef DEBUG
-
 >       deriving Show
-
-#endif
 
 > data Priority = No | Prio Assoc Int | PrioLowest
-
-#ifdef DEBUG
-
 >       deriving Show
-
-#endif
 
 > instance Eq Priority where
 >   No == No = True
@@ -608,15 +589,7 @@ So is this.
 >               | LR'Fail               -- :-(
 >               | LR'MustFail           -- :-(
 >               | LR'Multiple [LRAction] LRAction       -- conflict
->       deriving(Eq
-
-#ifdef DEBUG
-
->       ,Show
-
-#endif
-
->       )
+>       deriving (Eq,Show)
 
 > type ActionTable = Array Int{-state-} (Array Int{-terminal#-} LRAction)
 
@@ -629,14 +602,6 @@ So is this.
  instance Eq LRAction where { (==) = primGenericEq }
 
 > data Goto = Goto Int | NoGoto
->       deriving(Eq
-
-#ifdef DEBUG
-
->       ,Show
-
-#endif
-
->       )
+>       deriving (Eq, Show)
 
 > type GotoTable = Array Int{-state-} (Array Int{-nonterminal #-} Goto)

--- a/src/LALR.lhs
+++ b/src/LALR.lhs
@@ -35,23 +35,10 @@ Generation of LALR parsing tables.
 This means rule $a$, with dot at $b$ (all starting at 0)
 
 > data Lr0Item = Lr0 {-#UNPACK#-}!Int {-#UNPACK#-}!Int                  -- (rule, dot)
->       deriving (Eq,Ord
-
-#ifdef DEBUG
-
->       ,Show
-
-#endif
-
->       )
+>       deriving (Eq,Ord,Show)
 
 > data Lr1Item = Lr1 {-#UNPACK#-}!Int {-#UNPACK#-}!Int NameSet  -- (rule, dot, lookahead)
-
-#ifdef DEBUG
-
 >       deriving (Show)
-
-#endif
 
 > type RuleList = [Lr0Item]
 

--- a/src/Lexer.lhs
+++ b/src/Lexer.lhs
@@ -60,15 +60,7 @@ The lexer.
 >       | TokParenL             -- (
 >       | TokParenR             -- )
 >       | TokComma              -- ,
->       deriving (Eq,Ord
-
-#ifdef DEBUG
-
->               ,Show
-
-#endif
-
->               )
+>       deriving (Eq,Ord,Show)
 
 ToDo: proper text instance here, for use in parser error messages.
 

--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -82,11 +82,7 @@ Mangle the syntax into something useful.
 >               Left  s -> die (unlines s ++ "\n");
 >               Right g -> return g
 
-#ifdef DEBUG
-
 >       optPrint cli DumpMangle $ putStr $ show g
-
-#endif
 
 >       let first       = {-# SCC "First" #-} (mkFirst g)
 >           closures    = {-# SCC "Closures" #-} (precalcClosure0 g)
@@ -98,15 +94,13 @@ Mangle the syntax into something useful.
 >           action      = {-# SCC "Action" #-} (genActionTable g first items2)
 >           (conflictArray,(sr,rr))   = {-# SCC "Conflict" #-} (countConflicts action)
 
-#ifdef DEBUG
+Debug output
 
 >       optPrint cli DumpLR0    $ putStr $ show sets
 >       optPrint cli DumpAction $ putStr $ show action
 >       optPrint cli DumpGoto   $ putStr $ show goto
 >       optPrint cli DumpLA     $ putStr $ show _lainfo
 >       optPrint cli DumpLA     $ putStr $ show la
-
-#endif
 
 Report any unused rules and terminals
 
@@ -297,11 +291,9 @@ Successfully Finished.
 > dieHappy :: String -> IO a
 > dieHappy s = getProgramName >>= \prog -> die (prog ++ ": " ++ s)
 
-#ifdef DEBUG
 > optPrint :: [CLIFlags] -> CLIFlags -> IO () -> IO ()
 > optPrint cli pass io =
 >       when (elem pass cli) (putStr "\n---------------------\n" >> io)
-#endif
 
 > constArgs :: [String]
 > constArgs = []
@@ -377,16 +369,12 @@ selects what counts as a reduction when calculating used/unused
 The command line arguments.
 
 > data CLIFlags =
-#ifdef DEBUG
 >                 DumpMangle
 >               | DumpLR0
 >               | DumpAction
 >               | DumpGoto
 >               | DumpLA
->
->               |
-#endif
->                 DumpVersion
+>               | DumpVersion
 >               | DumpHelp
 >               | OptInfoFile (Maybe String)
 >               | OptPrettyFile (Maybe String)
@@ -437,23 +425,19 @@ The command line arguments.
 >    Option ['V','v'] ["version"] (NoArg DumpVersion)   -- ToDo: -v is deprecated
 >       "output version information and exit"
 
-#ifdef DEBUG
-
 Various debugging/dumping options...
 
 >    ,
->    Option [] ["mangle"] (NoArg DumpMangle)
+>    Option [] ["ddump-mangle"] (NoArg DumpMangle)
 >       "Dump mangled input",
->    Option [] ["lr0"] (NoArg DumpLR0)
+>    Option [] ["ddump-lr0"] (NoArg DumpLR0)
 >       "Dump LR0 item sets",
->    Option [] ["action"] (NoArg DumpAction)
+>    Option [] ["ddump-action"] (NoArg DumpAction)
 >       "Dump action table",
->    Option [] ["goto"] (NoArg DumpGoto)
+>    Option [] ["ddump-goto"] (NoArg DumpGoto)
 >       "Dump goto table",
->    Option [] ["lookaheads"] (NoArg DumpLA)
+>    Option [] ["ddump-lookaheads"] (NoArg DumpLA)
 >       "Dump lookahead info"
-
-#endif
 
 >    ]
 


### PR DESCRIPTION
Hiding this behind CPP is not necessary. GHC supports flags such as `-ddump-tc-trace` and users have no problem with this.