### PR TITLE
Split `BookendedAbsSyn` out from `AbsSyn`

### DIFF
--- a/packages/frontend/src/Happy/Frontend.hs
+++ b/packages/frontend/src/Happy/Frontend.hs
@@ -4,7 +4,7 @@ import Happy.Frontend.AbsSyn
 import Happy.Frontend.Parser
 import Happy.Frontend.ParseMonad.Class
 
-parseYFileContents :: String -> ParseResult AbsSyn
+parseYFileContents :: String -> ParseResult BookendedAbsSyn
 parseYFileContents contents = runFromStartP ourParser contents 1
 
 data FileType = Y | LY

--- a/packages/frontend/src/Happy/Frontend/AbsSyn.lhs
+++ b/packages/frontend/src/Happy/Frontend/AbsSyn.lhs
@@ -7,6 +7,7 @@ Abstract syntax for grammar files.
 Here is the abstract syntax of the language we parse.
 
 > module Happy.Frontend.AbsSyn (
+>       BookendedAbsSyn(..),
 >       AbsSyn(..), Directive(..),
 >       getTokenType, getTokenSpec, getParserNames, getLexer,
 >       getImportedIdentity, getMonad, getError,
@@ -17,12 +18,16 @@ Here is the abstract syntax of the language we parse.
 
 > import Happy.Grammar (ErrorHandlerType(..))
 
+> data BookendedAbsSyn
+>     = BookendedAbsSyn
+>         (Maybe String)       -- header
+>         AbsSyn
+>         (Maybe String)       -- footer
+
 > data AbsSyn
 >     = AbsSyn
->         (Maybe String)       -- header
 >         [Directive String]   -- directives
 >         [Rule]               -- productions
->         (Maybe String)       -- footer
 
 > data Rule
 >     = Rule

--- a/packages/frontend/src/Happy/Frontend/Mangler.lhs
+++ b/packages/frontend/src/Happy/Frontend/Mangler.lhs
@@ -50,7 +50,7 @@ This bit is a real mess, mainly because of the error message support.
 >   where (g, errs) = runWriter (manglerM file abssyn)
 
 > manglerM :: FilePath -> AbsSyn -> M Grammar
-> manglerM file (AbsSyn _hd dirs rules' _tl) =
+> manglerM file (AbsSyn dirs rules') =
 >   -- add filename to all error messages
 >   mapWriter (\(a,e) -> (a, map (\s -> file ++ ": " ++ s) e)) $ do
 

--- a/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
+++ b/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
@@ -8,7 +8,7 @@ The parser.
 
 > {
 > {-# OPTIONS_GHC -w #-}
-> module Happy.Frontend.Parser.Bootstrapped (ourParser,AbsSyn) where
+> module Happy.Frontend.Parser.Bootstrapped (ourParser) where
 > import Happy.Frontend.ParseMonad.Class
 > import Happy.Frontend.ParseMonad.Bootstrapped
 > import Happy.Frontend.AbsSyn
@@ -52,9 +52,11 @@ The parser.
 
 > %%
 
-> parser :: { AbsSyn }
->       : optCode tokInfos "%%" rules optCode
->                               { AbsSyn $1 (reverse $2) (reverse $4) $5 }
+> parser :: { BookendedAbsSyn }
+>       : optCode core_parser optCode   { BookendedAbsSyn $1 $2 $3 }
+
+> core_parser :: { AbsSyn }
+>       : tokInfos "%%" rules           { AbsSyn (reverse $1) (reverse $3) }
 
 > rules :: { [Rule] }
 >       : rules rule    { $2 : $1 }

--- a/packages/frontend/src/Happy/Frontend/Parser/Oracle.hs
+++ b/packages/frontend/src/Happy/Frontend/Parser/Oracle.hs
@@ -15,15 +15,20 @@ import Happy.Frontend.Lexer
 
 type Parser = P Token
 
-ourParser :: Parser AbsSyn
+ourParser :: Parser BookendedAbsSyn
 ourParser = do
   headerCode <- optCodeP
+  absSyn <- coreParser
+  footerCode <- optCodeP
+  eofP
+  return $ BookendedAbsSyn headerCode absSyn footerCode
+
+coreParser :: Parser AbsSyn
+coreParser = do
   tokInfos <- manyP optTokInfoP
   expectKW "Expected %%" TokDoublePercent
   rules <- rulesP
-  footerCode <- optCodeP
-  eofP
-  return (AbsSyn headerCode tokInfos rules footerCode)
+  return $ AbsSyn tokInfos rules
 
 optCodeP :: Parser (Maybe String)
 optCodeP = withToken match where

--- a/packages/frontend/src/Happy/Frontend/PrettyGrammar.hs
+++ b/packages/frontend/src/Happy/Frontend/PrettyGrammar.hs
@@ -10,7 +10,7 @@ render :: Doc -> String
 render = maybe "" ($ "")
 
 ppAbsSyn :: AbsSyn -> Doc
-ppAbsSyn (AbsSyn _ ds rs _) = vsep (vcat (map ppDirective ds) : map ppRule rs)
+ppAbsSyn (AbsSyn ds rs) = vsep (vcat (map ppDirective ds) : map ppRule rs)
 
 ppDirective :: Directive a -> Doc
 ppDirective dir =

--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -75,9 +75,9 @@ Open the file.
 
 Parse, using bootstrapping parser.
 
->       (abssyn, hd, tl) <- case parseYFileContents file of
+>       (BookendedAbsSyn hd abssyn tl) <- case parseYFileContents file of
 >               Left err -> die (fl_name ++ ':' : err)
->               Right abssyn@(AbsSyn hd _ _ tl) -> return (abssyn, hd, tl)
+>               Right bas -> return bas
 
 Mangle the syntax into something useful.
 


### PR DESCRIPTION
`BookendedAbsSyn` wraps it to separate the information needed by the
middle parts of happy from the header and footer which are just added
back at the end.

The code looks nicer to me now, with fewer wildcard and @-patterns,
therefore I conclude that this is makes the data structures more natural
for what we are doing.